### PR TITLE
Fixes #9 - s3 bucket name population

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.5]
+
+* Corrected bug where AWS CI/CD choice was not correctly populating S3 bucketname for install_modules.ps1
+* Bumped module references to latest versions
+
 ## [0.8.4]
 
 * Added Manifest File to Invoke-Build buildheader

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 0.8.3
+Help Version: 0.8.5
 Locale: en-US
 ---
 

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.8.4'
+    ModuleVersion     = '0.8.5'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Resources/AWS/install_modules.ps1
+++ b/src/Catesta/Resources/AWS/install_modules.ps1
@@ -45,25 +45,25 @@ $modulesToInstall = [System.Collections.ArrayList]::new()
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '4.9.0'
-            BucketName    = $PLASTER_PARAM_S3Bucket
+            BucketName    = <%=$PLASTER_PARAM_S3Bucket%>
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.5.5'
-            BucketName    = $PLASTER_PARAM_S3Bucket
+            ModuleVersion = '5.5.6'
+            BucketName    = <%=$PLASTER_PARAM_S3Bucket%>
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.18.0'
-            BucketName    = $PLASTER_PARAM_S3Bucket
+            ModuleVersion = '1.18.3'
+            BucketName    = <%=$PLASTER_PARAM_S3Bucket%>
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'platyPS'
             ModuleVersion = '0.12.0'
-            BucketName    = $PLASTER_PARAM_S3Bucket
+            BucketName    = <%=$PLASTER_PARAM_S3Bucket%>
             KeyPrefix     = ''
         }))
 

--- a/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
@@ -16,7 +16,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.5.5'
+            ModuleVersion = '5.5.6'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/src/Catesta/Resources/Azure/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/Azure/actions_bootstrap.ps1
@@ -16,7 +16,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.5.5'
+            ModuleVersion = '5.5.6'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
@@ -16,7 +16,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.5.5'
+            ModuleVersion = '5.5.6'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{


### PR DESCRIPTION
# Pull Request

## Issue

#9 

## Description

Description of changes:

* Corrected bug where AWS CI/CD choice was not correctly populating S3 bucketname for install_modules.ps1
* Bumped module references to latest versions

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
