### PR TITLE
Enhancements

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.9]
+
+* Bug fix - After build the Imports.ps1 file was being left in the artifacts folder. It will now be removed after build is completed.
+* Bug fix - when AWS CI/CD was chosen and an S3 bucket was provided for module install the modules were not correctly downloading to the build container. Fixed temp path issue and bucket name quotes added.
+* Bug fix - Build file when running in 5.1 was not honoring the "*.ps1" filter and would pick up files like ps1xml. Changed to a regex so that both 5.1 and higher versions work. This was causing ps1xml files to merged into the psm1 during build.
+* Bug fix - Fixed Module name not being replaced in SampleInfraTest.Tests.ps1
+
 ## [0.8.5]
 
 * Corrected bug where AWS CI/CD choice was not correctly populating S3 bucketname for install_modules.ps1

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 0.8.5
+Help Version: 0.8.7
 Locale: en-US
 ---
 

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 0.8.7
+Help Version: 0.8.9
 Locale: en-US
 ---
 

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.8.7'
+    ModuleVersion     = '0.8.8'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.8.8'
+    ModuleVersion     = '0.8.9'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.8.5'
+    ModuleVersion     = '0.8.6'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.8.6'
+    ModuleVersion     = '0.8.7'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Resources/AWS/install_modules.ps1
+++ b/src/Catesta/Resources/AWS/install_modules.ps1
@@ -45,80 +45,80 @@ $modulesToInstall = [System.Collections.ArrayList]::new()
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '4.9.0'
-            BucketName    = <%=$PLASTER_PARAM_S3Bucket%>
+            BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
             ModuleVersion = '5.5.6'
-            BucketName    = <%=$PLASTER_PARAM_S3Bucket%>
+            BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
             ModuleVersion = '1.18.3'
-            BucketName    = <%=$PLASTER_PARAM_S3Bucket%>
+            BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'platyPS'
             ModuleVersion = '0.12.0'
-            BucketName    = <%=$PLASTER_PARAM_S3Bucket%>
+            BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))
 
-#install the correct version of AWSPowerShell module
-# $tempPath = [System.IO.Path]::GetTempPath()
-# if ($PSVersionTable.Platform -eq 'Win32NT') {
-#     #Core-Windows
-#     $moduleInstallPath = [System.IO.Path]::Combine($env:ProgramFiles, 'WindowsPowerShell', 'Modules')
-#     if ($PSEdition -eq 'Core') {
-#         $moduleInstallPath = [System.IO.Path]::Combine($env:ProgramFiles, 'PowerShell', 'Modules')
-#         # Add the AWSPowerShell.NetCore Module
-#         $null = $modulesToInstall.Add(([PSCustomObject]@{
-#                     ModuleName    = 'AWSPowerShell.NetCore'
-#                     ModuleVersion = '3.3.498.0'
-#                     BucketName    = 'ps-invoke-modules'
-#                     KeyPrefix     = ''
-#                 }))
-#     }
-#     else {
-#         $moduleInstallPath = [System.IO.Path]::Combine($env:ProgramFiles, 'WindowsPowerShell', 'Modules')
-#         # Add the AWSPowerShell Module
-#         $null = $modulesToInstall.Add(([PSCustomObject]@{
-#                     ModuleName    = 'AWSPowerShell'
-#                     ModuleVersion = '3.3.498.0'
-#                     BucketName    = 'ps-invoke-modules'
-#                     KeyPrefix     = ''
-#                 }))
-#     }
-# }
-# elseif ($PSVersionTable.Platform -eq 'Unix') {
-#     $moduleInstallPath = [System.IO.Path]::Combine('/', 'usr', 'local', 'share', 'powershell', 'Modules')
-
-#     # Add the AWSPowerShell.NetCore Module
-#     $null = $modulesToInstall.Add(([PSCustomObject]@{
-#                 ModuleName    = 'AWSPowerShell.NetCore'
-#                 ModuleVersion = '3.3.498.0'
-#                 BucketName    = 'ps-invoke-modules'
-#                 KeyPrefix     = ''
-#             }))
-# }
-# elseif ($PSEdition -eq 'Desktop') {
-#     $moduleInstallPath = [System.IO.Path]::Combine($env:ProgramFiles, 'WindowsPowerShell', 'Modules')
-#     # Add the AWSPowerShell Module
-#     $null = $modulesToInstall.Add(([PSCustomObject]@{
-#                 ModuleName    = 'AWSPowerShell'
-#                 ModuleVersion = '3.3.498.0'
-#                 BucketName    = 'ps-invoke-modules'
-#                 KeyPrefix     = ''
-#             }))
-# }
-# else {
-#     throw 'Unrecognized OS platform'
-# }
-
 if ($galleryDownload -eq $false) {
+
+    $tempPath = [System.IO.Path]::GetTempPath()
+
+    if ($PSVersionTable.Platform -eq 'Win32NT') {
+        $moduleInstallPath = [System.IO.Path]::Combine($env:ProgramFiles, 'WindowsPowerShell', 'Modules')
+        if ($PSEdition -eq 'Core') {
+            $moduleInstallPath = [System.IO.Path]::Combine($env:ProgramFiles, 'PowerShell', 'Modules')
+            # Add the AWSPowerShell.NetCore Module
+            # $null = $modulesToInstall.Add(([PSCustomObject]@{
+            #     ModuleName    = 'AWSPowerShell.NetCore'
+            #     ModuleVersion = '3.3.604.0'
+            #     BucketName    = 'ps-invoke-modules'
+            #     KeyPrefix     = ''
+            # }))
+        }
+        else {
+            $moduleInstallPath = [System.IO.Path]::Combine($env:ProgramFiles, 'WindowsPowerShell', 'Modules')
+            # Add the AWSPowerShell Module
+            # $null = $modulesToInstall.Add(([PSCustomObject]@{
+            #     ModuleName    = 'AWSPowerShell'
+            #     ModuleVersion = '3.3.604.0'
+            #     BucketName    = 'ps-invoke-modules'
+            #     KeyPrefix     = ''
+            # }))
+        }
+    }
+    elseif ($PSVersionTable.Platform -eq 'Unix') {
+        $moduleInstallPath = [System.IO.Path]::Combine('/', 'usr', 'local', 'share', 'powershell', 'Modules')
+
+        # Add the AWSPowerShell.NetCore Module
+        # $null = $modulesToInstall.Add(([PSCustomObject]@{
+        #     ModuleName    = 'AWSPowerShell.NetCore'
+        #     ModuleVersion = '3.3.604.0'
+        #     BucketName    = 'ps-invoke-modules'
+        #     KeyPrefix     = ''
+        # }))
+    }
+    elseif ($PSEdition -eq 'Desktop') {
+        $moduleInstallPath = [System.IO.Path]::Combine($env:ProgramFiles, 'WindowsPowerShell', 'Modules')
+        # Add the AWSPowerShell Module
+        # $null = $modulesToInstall.Add(([PSCustomObject]@{
+        #     ModuleName    = 'AWSPowerShell'
+        #     ModuleVersion = '3.3.604.0'
+        #     BucketName    = 'ps-invoke-modules'
+        #     KeyPrefix     = ''
+        # }))
+    }
+    else {
+        throw 'Unrecognized OS platform'
+    }
+
     'Installing PowerShell Modules'
     foreach ($module in $modulesToInstall) {
         '  - {0} {1}' -f $module.ModuleName, $module.ModuleVersion

--- a/src/Catesta/Resources/AWS/plasterManifest.xml
+++ b/src/Catesta/Resources/AWS/plasterManifest.xml
@@ -77,7 +77,7 @@
     <templateFile source='..\Module\src\Tests\Unit\PSModule-Module.Tests.ps1' destination='src\Tests\Unit\${PLASTER_PARAM_ModuleName}-Module.Tests.ps1' />
     <templateFile source='..\Module\src\Tests\Unit\ExportedFunctions.Tests.ps1' destination='src\Tests\Unit\ExportedFunctions.Tests.ps1' />
     <templateFile source='..\Module\src\Tests\Unit\Module-Function.Tests.ps1' destination='src\Tests\Unit\${PLASTER_PARAM_ModuleName}-Function.Tests.ps1' />
-    <file source='..\Module\src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' destination='src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' />
+    <templateFile source='..\Module\src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' destination='src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' />
 
     <templateFile source='..\Module\src\Module\Public\Get-HelloWorld.ps1' destination='src\${PLASTER_PARAM_ModuleName}\Public\Get-HelloWorld.ps1' />
     <templateFile source='..\Module\src\Module\Private\Get-PrivateHelloWorld.ps1' destination='src\${PLASTER_PARAM_ModuleName}\Private\Get-PrivateHelloWorld.ps1' />

--- a/src/Catesta/Resources/Azure/plasterManifest.xml
+++ b/src/Catesta/Resources/Azure/plasterManifest.xml
@@ -71,7 +71,7 @@
     <templateFile source='..\Module\src\Tests\Unit\PSModule-Module.Tests.ps1' destination='src\Tests\Unit\${PLASTER_PARAM_ModuleName}-Module.Tests.ps1' />
     <templateFile source='..\Module\src\Tests\Unit\ExportedFunctions.Tests.ps1' destination='src\Tests\Unit\ExportedFunctions.Tests.ps1' />
     <templateFile source='..\Module\src\Tests\Unit\Module-Function.Tests.ps1' destination='src\Tests\Unit\${PLASTER_PARAM_ModuleName}-Function.Tests.ps1' />
-    <file source='..\Module\src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' destination='src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' />
+    <templateFile source='..\Module\src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' destination='src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' />
 
     <templateFile source='..\Module\src\Module\Public\Get-HelloWorld.ps1' destination='src\${PLASTER_PARAM_ModuleName}\Public\Get-HelloWorld.ps1' />
     <templateFile source='..\Module\src\Module\Private\Get-PrivateHelloWorld.ps1' destination='src\${PLASTER_PARAM_ModuleName}\Private\Get-PrivateHelloWorld.ps1' />

--- a/src/Catesta/Resources/GitHubActions/plasterManifest.xml
+++ b/src/Catesta/Resources/GitHubActions/plasterManifest.xml
@@ -71,7 +71,7 @@
     <templateFile source='..\Module\src\Tests\Unit\PSModule-Module.Tests.ps1' destination='src\Tests\Unit\${PLASTER_PARAM_ModuleName}-Module.Tests.ps1' />
     <templateFile source='..\Module\src\Tests\Unit\ExportedFunctions.Tests.ps1' destination='src\Tests\Unit\ExportedFunctions.Tests.ps1' />
     <templateFile source='..\Module\src\Tests\Unit\Module-Function.Tests.ps1' destination='src\Tests\Unit\${PLASTER_PARAM_ModuleName}-Function.Tests.ps1' />
-    <file source='..\Module\src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' destination='src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' />
+    <templateFile source='..\Module\src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' destination='src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' />
 
     <templateFile source='..\Module\src\Module\Public\Get-HelloWorld.ps1' destination='src\${PLASTER_PARAM_ModuleName}\Public\Get-HelloWorld.ps1' />
     <templateFile source='..\Module\src\Module\Private\Get-PrivateHelloWorld.ps1' destination='src\${PLASTER_PARAM_ModuleName}\Private\Get-PrivateHelloWorld.ps1' />

--- a/src/Catesta/Resources/Module/src/PSModule.build.ps1
+++ b/src/Catesta/Resources/Module/src/PSModule.build.ps1
@@ -435,7 +435,9 @@ Add-BuildTask Build {
     if (Test-Path "$($script:ArtifactsPath)\Private") {
         Remove-Item "$($script:ArtifactsPath)\Private" -Recurse -Force -ErrorAction Stop
     }
-
+    if (Test-Path "$($script:ArtifactsPath)\Imports.ps1") {
+        Remove-Item "$($script:ArtifactsPath)\Imports.ps1" -Force -ErrorAction SilentlyContinue
+    }
     # here you could move your docs up to your repos doc level if you wanted
     # Write-Build Gray '        Overwriting docs output...'
     # Move-Item "$($script:ArtifactsPath)\docs\*.md" -Destination "..\docs\" -Force

--- a/src/Catesta/Resources/Module/src/PSModule.build.ps1
+++ b/src/Catesta/Resources/Module/src/PSModule.build.ps1
@@ -418,7 +418,7 @@ Add-BuildTask Build {
     #$private = "$script:ModuleSourcePath\Private"
     $scriptContent = [System.Text.StringBuilder]::new()
     #$powerShellScripts = Get-ChildItem -Path $script:ModuleSourcePath -Filter '*.ps1' -Recurse
-    $powerShellScripts = Get-ChildItem -Path $script:ArtifactsPath -Filter '*.ps1' -Recurse
+    $powerShellScripts = Get-ChildItem -Path $script:ArtifactsPath -Recurse | Where-Object {$_.Name -match '^*.ps1$'}
     foreach ($script in $powerShellScripts) {
         $null = $scriptContent.Append((Get-Content -Path $script.FullName -Raw))
         $null = $scriptContent.AppendLine('')

--- a/src/Catesta/Resources/Module/src/Tests/InfraStructure/SampleInfraTest.Tests.ps1
+++ b/src/Catesta/Resources/Module/src/Tests/InfraStructure/SampleInfraTest.Tests.ps1
@@ -9,7 +9,7 @@
 # #-------------------------------------------------------------------------
 # Import-Module $PathToManifest -Force
 # #-------------------------------------------------------------------------
-# Describe 'Infrastructure Tests' {
+# Describe 'Infrastructure Tests' -Tag Infrastructure {
 #     Context 'First Infra Tests' {
 #         It 'should pass the first infra test' {
 #             # test logic

--- a/src/Catesta/Resources/Vanilla/plasterManifest.xml
+++ b/src/Catesta/Resources/Vanilla/plasterManifest.xml
@@ -34,7 +34,7 @@
     <templateFile source='..\Module\src\Tests\Unit\PSModule-Module.Tests.ps1' destination='src\Tests\Unit\${PLASTER_PARAM_ModuleName}-Module.Tests.ps1' />
     <templateFile source='..\Module\src\Tests\Unit\ExportedFunctions.Tests.ps1' destination='src\Tests\Unit\ExportedFunctions.Tests.ps1' />
     <templateFile source='..\Module\src\Tests\Unit\Module-Function.Tests.ps1' destination='src\Tests\Unit\${PLASTER_PARAM_ModuleName}-Function.Tests.ps1' />
-    <file source='..\Module\src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' destination='src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' />
+    <templateFile source='..\Module\src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' destination='src\Tests\Infrastructure\SampleInfraTest.Tests.ps1' />
 
     <templateFile source='..\Module\src\Module\Public\Get-HelloWorld.ps1' destination='src\${PLASTER_PARAM_ModuleName}\Public\Get-HelloWorld.ps1' />
     <templateFile source='..\Module\src\Module\Private\Get-PrivateHelloWorld.ps1' destination='src\${PLASTER_PARAM_ModuleName}\Private\Get-PrivateHelloWorld.ps1' />


### PR DESCRIPTION
# Pull Request

## Issue

Fixes #11 Fixes #12 Fixes #13 Fixes #14

## Description

Description of changes:

* Bug fix - After build the Imports.ps1 file was being left in the artifacts folder. It will now be removed after build is completed.
* Bug fix - when AWS CI/CD was chosen and an S3 bucket was provided for module install the modules were not correctly downloading to the build container. Fixed temp path issue and bucket name quotes added.
* Bug fix - Build file when running in 5.1 was not honoring the "*.ps1" filter and would pick up files like ps1xml. Changed to a regex so that both 5.1 and higher versions work. This was causing ps1xml files to merged into the psm1 during build.
* Bug fix - Fixed Module name not being replaced in SampleInfraTest.Tests.ps1

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
