### PR TITLE
Enhancements

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.9]
+
+* Bug fix - After build the Imports.ps1 file was being left in the artifacts folder. It will now be removed after build is completed.
+* Bug fix - when AWS CI/CD was chosen and an S3 bucket was provided for module install the modules were not correctly downloading to the build container. Fixed temp path issue and bucket name quotes added.
+* Bug fix - Build file when running in 5.1 was not honoring the "*.ps1" filter and would pick up files like ps1xml. Changed to a regex so that both 5.1 and higher versions work. This was causing ps1xml files to merged into the psm1 during build.
+* Bug fix - Fixed Module name not being replaced in SampleInfraTest.Tests.ps1
+
 ## [0.8.5]
 
 * Corrected bug where AWS CI/CD choice was not correctly populating S3 bucketname for install_modules.ps1

--- a/src/Catesta/Resources/Module/src/Tests/InfraStructure/SampleInfraTest.Tests.ps1
+++ b/src/Catesta/Resources/Module/src/Tests/InfraStructure/SampleInfraTest.Tests.ps1
@@ -9,7 +9,7 @@
 # #-------------------------------------------------------------------------
 # Import-Module $PathToManifest -Force
 # #-------------------------------------------------------------------------
-# Describe 'Infrastructure Tests' {
+# Describe 'Infrastructure Tests' -Tag Infrastructure {
 #     Context 'First Infra Tests' {
 #         It 'should pass the first infra test' {
 #             # test logic


### PR DESCRIPTION
# Pull Request

## Issue

Get-Help New-PowerShellProject -Online was not opening the correct online webpage.

## Description

Description of changes:

* Added link to the online function documentation for New-PowerShellProject as its first link so it will open directly when `Get-Help -Name New-PowerShellProject -Online` is called.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
