### PR TITLE
Enhancements

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,42 +5,95 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0]
+
+- Catesta primary module changes
+  - ExportedFunctions.Tests.ps1 - Corrected 2 bugs in Exported Commands test
+    - Didn't correctly identify all commands
+    - Didn't support example checks in PowerShell 5.1
+  - Catesta manifest updates
+    - Updated to use more recent versions of required modules
+    - Sorted tags alphabetically
+  - Catesta.build.ps1
+    - Updated verbiage in ValidateRequirements to correctly reflect version of PowerShell required
+    - Updated Add-BuildTask Test to output Pester test outputfile to testOutput location
+    - Updated Add-BuildTask Test to correctly output Pester code coverage file
+  - Updated tasks.json to reference ${workspaceFolder}
+- Catesta template module changes
+  - Build updates
+    - Corrected 2 bugs in Exported Commands test
+      - Didn't correctly identify all commands
+      - Didn't support example checks in PowerShell 5.1
+    - PSModule.build.ps1
+      - Updated verbiage in ValidateRequirements to correctly reflect version of PowerShell required
+      - Updated Add-BuildTask Test to output Pester test outputfile to testOutput location
+      - Updated Add-BuildTask Test to correctly output Pester code coverage file
+  - AWS Updates
+    - Updated CFN deployments to use latest CodeBuild Images (2019)
+      - windows-base:1.0 --> windows-base:2019-1.0
+    - Updated buildspec_pwsh_windows.yml to download PowerShell 7.0.3 instead of 7.0.0
+    - Updated module references to latest version
+    - Added AWS.Tools.Common to install_modules.ps1
+    - Added $PSVersionTable to pre_build commands of all yml files
+    - Added support for Pester report groups in CodeBuild
+    - Added support for Code Coverage reports groups in CodeBuild
+  - Azure Updates
+    - Added clarifying display names to each task
+    - Added support for publishing test results
+    - Added support for Code Coverage report
+    - Updated actions_bootstrap.ps1 to install latest module versions
+    - For windows powershell based build added line to remove Pester 5 and Import Pester 4.10.1 specifically.
+    - Added support for attaching build artifact of Archived module build
+  - GitHub Actions
+    - Updated actions_bootstrap.ps1 to install latest module versions
+    - Added name to all workflows for check out step
+    - Changed checkout on all workflows from v1 to v2
+    - Added pester test results artifact upload to all workflows
+    - Renamed windows workflow that was using pwsh to ActionsTest-Windows-pwsh-Build
+    - For windows powershell based build added line to remove Pester 5 and Import Pester 4.10.1 specifically.
+  - Appveyor Updates
+    - Updated actions_bootstrap.ps1 to install latest module versions
+    - For windows powershell based build added line to remove Pester 5 and Import Pester 4.10.1 specifically.
+    - Added support for all appveyor builds to include PesterTest, CodeCoverage, and build artifacts
+- Editor updates
+  - Added InvokeBuild tasks to tasks.json
+
 ## [0.8.12]
 
-* Updated Pester and InvokeBuild module references to latest versions
-* AWS:
-  * buildspec_pwsh_windows.yml now uses PowerShell 7 instead of PowerShell 6.3
-* Minor build updates:
-  * Updated tasks.json for better integration with InvokeBuild
-
+- Updated Pester and InvokeBuild module references to latest versions
+- AWS:
+  - buildspec_pwsh_windows.yml now uses PowerShell 7 instead of PowerShell 6.3
+- Minor build updates:
+  - Updated tasks.json for better integration with InvokeBuild
+1
 ## [0.8.10]
 
-* Added link to the online function documentation for New-PowerShellProject as its first link so it will open directly when `Get-Help -Name New-PowerShellProject -Online` is called.
+- Added link to the online function documentation for New-PowerShellProject as its first link so it will open directly when `Get-Help -Name New-PowerShellProject -Online` is called.
 
 ## [0.8.9]
 
-* Bug fix - After build the Imports.ps1 file was being left in the artifacts folder. It will now be removed after build is completed.
-* Bug fix - when AWS CI/CD was chosen and an S3 bucket was provided for module install the modules were not correctly downloading to the build container. Fixed temp path issue and bucket name quotes added.
-* Bug fix - Build file when running in 5.1 was not honoring the "*.ps1" filter and would pick up files like ps1xml. Changed to a regex so that both 5.1 and higher versions work. This was causing ps1xml files to merged into the psm1 during build.
-* Bug fix - Fixed Module name not being replaced in SampleInfraTest.Tests.ps1
+- Bug fix - After build the Imports.ps1 file was being left in the artifacts folder. It will now be removed after build is completed.
+- Bug fix - when AWS CI/CD was chosen and an S3 bucket was provided for module install the modules were not correctly downloading to the build container. Fixed temp path issue and bucket name quotes added.
+- Bug fix - Build file when running in 5.1 was not honoring the "*.ps1" filter and would pick up files like ps1xml. Changed to a regex so that both 5.1 and higher versions work. This was causing ps1xml files to merged into the psm1 during build.
+- Bug fix - Fixed Module name not being replaced in SampleInfraTest.Tests.ps1
 
 ## [0.8.5]
 
-* Corrected bug where AWS CI/CD choice was not correctly populating S3 bucketname for install_modules.ps1
-* Bumped module references to latest versions
+- Corrected bug where AWS CI/CD choice was not correctly populating S3 bucketname for install_modules.ps1
+- Bumped module references to latest versions
 
 ## [0.8.4]
 
-* Added Manifest File to Invoke-Build buildheader
-* Added Manifest version to Invoke-Build buildheader
-* Corrected bug in Catesta's build process that wasn't displaying Manifest info in the buildheader
+- Added Manifest File to Invoke-Build buildheader
+- Added Manifest version to Invoke-Build buildheader
+- Corrected bug in Catesta's build process that wasn't displaying Manifest info in the buildheader
 
 ## [0.8.3]
 
-* Moved Infrastructure tests from pre-build to post build
-  * Included sample Infrastructure test that references artifacts location for import for post-build import.
-* Corrected spelling error in Tests folder: Infrastrcuture to Infrastructure
+- Moved Infrastructure tests from pre-build to post build
+  - Included sample Infrastructure test that references artifacts location for import for post-build import.
+- Corrected spelling error in Tests folder: Infrastrcuture to Infrastructure
 
 ## [0.8.0]
 
-* Initial release.
+- Initial release.

--- a/.github/workflows/wf_Linux.yml
+++ b/.github/workflows/wf_Linux.yml
@@ -3,6 +3,7 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
+# https://github.com/actions/upload-artifact#where-does-the-upload-go
 name: Catesta-Linux
 on: [push, pull_request]
 jobs:
@@ -12,7 +13,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - name: Check out repository
+      uses: actions/checkout@v2
     - name: Display the path
       shell: pwsh
       run: echo ${env:GITHUB_WORKSPACE}
@@ -25,3 +27,15 @@ jobs:
     - name: Test and Build
       shell: pwsh
       run: Invoke-Build -File .\src\Catesta.build.ps1
+    - name: Upload pester results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pester-results
+        path: ./src/Artifacts/testOutput
+        if-no-files-found: warn
+    - name: Upload zip module archive build
+      uses: actions/upload-artifact@v2
+      with:
+        name: zip-archive
+        path: ./src/Archive
+        if-no-files-found: warn

--- a/.github/workflows/wf_MacOS.yml
+++ b/.github/workflows/wf_MacOS.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - name: Check out repository
+      uses: actions/checkout@v2
     - name: Display the path
       shell: pwsh
       run: echo ${env:GITHUB_WORKSPACE}
@@ -25,3 +26,15 @@ jobs:
     - name: Test and Build
       shell: pwsh
       run: Invoke-Build -File .\src\Catesta.build.ps1
+    - name: Upload pester results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pester-results
+        path: ./src/Artifacts/testOutput
+        if-no-files-found: warn
+    - name: Upload zip module archive build
+      uses: actions/upload-artifact@v2
+      with:
+        name: zip-archive
+        path: ./src/Archive
+        if-no-files-found: warn

--- a/.github/workflows/wf_Windows.yml
+++ b/.github/workflows/wf_Windows.yml
@@ -25,7 +25,7 @@ jobs:
       run: ./actions_bootstrap.ps1
     - name: Test and Build
       shell: powershell
-      run: Remove-Module Pester -ErrorAction SilentlyContinue;Invoke-Build -File .\src\Catesta.build.ps1
+      run: Remove-Module Pester -ErrorAction SilentlyContinue;Import-Module Pester -RequiredVersion 4.10.1;Invoke-Build -File .\src\Catesta.build.ps1
     - name: Upload pester results
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/wf_Windows.yml
+++ b/.github/workflows/wf_Windows.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - name: Check out repository
+      uses: actions/checkout@v2
     - name: Display the path
       shell: powershell
       run: echo ${env:GITHUB_WORKSPACE}
@@ -24,4 +25,16 @@ jobs:
       run: ./actions_bootstrap.ps1
     - name: Test and Build
       shell: powershell
-      run: Invoke-Build -File .\src\Catesta.build.ps1
+      run: Remove-Module Pester -ErrorAction SilentlyContinue;Invoke-Build -File .\src\Catesta.build.ps1
+    - name: Upload pester results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pester-results
+        path: .\src\Artifacts\testOutput
+        if-no-files-found: warn
+    - name: Upload zip module archive build
+      uses: actions/upload-artifact@v2
+      with:
+        name: zip-archive
+        path: .\src\Archive
+        if-no-files-found: warn

--- a/.github/workflows/wf_Windows_Core.yml
+++ b/.github/workflows/wf_Windows_Core.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - name: Check out repository
+      uses: actions/checkout@v2
     - name: Display the path
       shell: pwsh
       run: echo ${env:GITHUB_WORKSPACE}
@@ -25,3 +26,15 @@ jobs:
     - name: Test and Build
       shell: pwsh
       run: Invoke-Build -File .\src\Catesta.build.ps1
+    - name: Upload pester results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pester-results
+        path: .\src\Artifacts\testOutput
+        if-no-files-found: warn
+    - name: Upload zip module archive build
+      uses: actions/upload-artifact@v2
+      with:
+        name: zip-archive
+        path: .\src\Archive
+        if-no-files-found: warn

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,10 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
+        "redhat.vscode-yaml",
+        "aws-scripting-guy.cform",
+        "danielthielking.aws-cloudformation-yaml",
+        "kddejong.vscode-cfn-lint",
         "ms-vscode.PowerShell",
         "ryanluker.vscode-coverage-gutters",
         "DavidAnson.vscode-markdownlint"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "[powershell]": {
         "files.encoding": "utf8bom",
         "files.autoGuessEncoding": true,
-        "editor.formatOnSave": true
+        "editor.formatOnSave": false
     },
     "files.trimTrailingWhitespace": true,
     "powershell.codeFormatting.preset":"Stroustrup"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
+    "[powershell]": {
+        "files.encoding": "utf8bom",
+        "files.autoGuessEncoding": true,
+        "editor.formatOnSave": true
+    },
     "files.trimTrailingWhitespace": true,
     "powershell.codeFormatting.preset":"Stroustrup"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -54,15 +54,15 @@
             "problemMatcher": [
                 "$pester"
             ],
-            "command": "Invoke-Pester '${workspaceFolder}/src/Tests/Unit' -PesterOption @{IncludeVSCodeMarker=$true}",
+            "command": "Invoke-Pester '${workspaceFolder}/src/Tests/Unit' -PesterOption @{IncludeVSCodeMarker=$true}"
         },
         {
             "label": ".",
             "type": "shell",
             "problemMatcher": "$msCompile",
-            "command": "$PSVersionTable;Invoke-Build -Task . -File './src/Catesta.build.ps1'",
+            "command": "$PSVersionTable;Invoke-Build -Task . -File '${workspaceFolder}/src/Catesta.build.ps1'",
             "group": {
-                "kind": "build",
+                "kind": "test",
                 "isDefault": true
             }
         },
@@ -70,67 +70,67 @@
             "label": "TestLocal",
             "type": "shell",
             "problemMatcher": "$msCompile",
-            "command": "Invoke-Build -Task TestLocal -File './src/Catesta.build.ps1'"
+            "command": "Invoke-Build -Task TestLocal -File '${workspaceFolder}/src/Catesta.build.ps1'"
         },
         {
             "label": "HelpLocal",
             "type": "shell",
             "problemMatcher": "$msCompile",
-            "command": "Invoke-Build -Task HelpLocal -File './src/Catesta.build.ps1'"
+            "command": "Invoke-Build -Task HelpLocal -File '${workspaceFolder}/src/Catesta.build.ps1'"
         },
         {
             "label": "Clean",
             "type": "shell",
             "problemMatcher": "$msCompile",
-            "command": "Invoke-Build -Task Clean -File './src/Catesta.build.ps1'"
+            "command": "Invoke-Build -Task Clean -File '${workspaceFolder}/src/Catesta.build.ps1'"
         },
         {
             "label": "ValidateRequirements",
             "type": "shell",
             "problemMatcher": "$msCompile",
-            "command": "Invoke-Build -Task ValidateRequirements -File './src/Catesta.build.ps1'"
+            "command": "Invoke-Build -Task ValidateRequirements -File '${workspaceFolder}/src/Catesta.build.ps1'"
         },
         {
             "label": "Analyze",
             "type": "shell",
             "problemMatcher": "$msCompile",
-            "command": "Invoke-Build -Task Analyze -File './src/Catesta.build.ps1'"
+            "command": "Invoke-Build -Task Analyze -File '${workspaceFolder}/src/Catesta.build.ps1'"
         },
         {
             "label": "AnalyzeTests",
             "type": "shell",
             "problemMatcher": "$msCompile",
-            "command": "Invoke-Build -Task AnalyzeTests -File './src/Catesta.build.ps1'"
+            "command": "Invoke-Build -Task AnalyzeTests -File '${workspaceFolder}/src/Catesta.build.ps1'"
         },
         {
             "label": "FormattingCheck",
             "type": "shell",
             "problemMatcher": "$msCompile",
-            "command": "Invoke-Build -Task FormattingCheck -File './src/Catesta.build.ps1'"
+            "command": "Invoke-Build -Task FormattingCheck -File '${workspaceFolder}/src/Catesta.build.ps1'"
         },
         {
             "label": "Test",
             "type": "shell",
             "problemMatcher": "$msCompile",
-            "command": "Invoke-Build -Task Test -File './src/Catesta.build.ps1'"
+            "command": "Invoke-Build -Task Test -File '${workspaceFolder}/src/Catesta.build.ps1'"
         },
         {
             "label": "DevCC",
             "type": "shell",
             "problemMatcher": "$msCompile",
-            "command": "Invoke-Build -Task DevCC -File './src/Catesta.build.ps1'"
+            "command": "Invoke-Build -Task DevCC -File '${workspaceFolder}/src/Catesta.build.ps1'"
         },
         {
             "label": "Build",
             "type": "shell",
             "problemMatcher": "$msCompile",
-            "command": "Invoke-Build -Task Build -File './src/Catesta.build.ps1'"
+            "command": "Invoke-Build -Task Build -File '${workspaceFolder}/src/Catesta.build.ps1'"
         },
         {
             "label": "InfraTest",
             "type": "shell",
             "problemMatcher": "$msCompile",
-            "command": "Invoke-Build -Task InfraTest -File './src/Catesta.build.ps1'"
+            "command": "Invoke-Build -Task InfraTest -File '${workspaceFolder}/src/Catesta.build.ps1'"
         }
     ]
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Jake Morrison
+Copyright (c) 2020 Jake Morrison
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -24,11 +24,17 @@ Catesta is a PowerShell module project generator. It uses templates to rapidly s
 
 ## Description
 
-* Catesta scaffolds an empty PowerShell project that adheres to PowerShell community guidelines.
-* It generates a few Pester tests to get you started.
-* It makes a build file that analyzes your code for best practices and styling, runs the Pester tests, creates PowerShell help, and combines your functions together to build your project for publication.
+Catesta enables you to quickly scaffold a PowerShell module project with proper formatting, test + build automation, CI/CD integration, with just one line of code.
+
+* Catesta scaffolds an empty PowerShell module project that adheres to PowerShell community guidelines.
+* It generates a few [Pester](https://github.com/pester/Pester) tests to get you started.
+* It makes a [build file](https://github.com/nightroman/Invoke-Build) that analyzes your code for best practices and styling, runs Pester tests, creates PowerShell help, and combines your functions together to build your project for publication.
 * It will create resources you need to trigger CI/CD builds for your module.
 * When you commit your code to your chosen repository, the build(s) will run, and you can view the results.
+
+## Why
+
+Simplify the process of structuring your module so that you can focus on building a great PowerShell module instead of the layout and build requirements.
 
 ### Features
 
@@ -67,10 +73,6 @@ Catesta is a PowerShell module project generator. It uses templates to rapidly s
       * Issue Feature Request
       * Pull Request
 
-## Why
-
-Simplify the process of structuring your module so that you can focus on building a great PowerShell module instead of the layout and build requirements.
-
 ## Installation
 
 ```powershell
@@ -102,16 +104,21 @@ New-PowerShellProject -CICDChoice 'ModuleOnly' -DestinationPath c:\path\ModuleOn
 1. Use Catesta to scaffold your PowerShell project with your desired CI/CD platform and builds.
 1. Write your module (the hardest part)
     * All build testing can be done locally by navigating to src and running ```Invoke-Build```
+    * If using VSCode as your primary editor you can use tasks to perform various local actions
+      * ```Press Ctrl+P, then type 'task test'```
 1. Commit your project to desired repository that is integrated with your CI/CD platform. This will trigger the build actions.
 1. Evaluate results of your builds and [display your README badges](https://github.com/techthoughts2/Catesta/blob/master/docs/Catesta-FAQ.md#how-do-i-display-the-badges-for-my-project) proudly!
 
-Additional Catesta documentation:
+Additional Catesta documentation that covers the process of CI/CD integration in depth:
 
 * [Catesta - AWS Doc](docs/Catesta-AWS.md)
 * [Catesta - GitHub Actions Doc](docs/Catesta-GHActions.md)
 * [Catesta - Azure Pipelines Doc](docs/Catesta-Azure.md)
 * [Catesta - GitHub AppVeyor Doc](docs/Catesta-AppVeyor.md)
-* **[Catesta - FAQ](docs/Catesta-FAQ.md)**
+
+## FAQ
+
+**[Catesta - FAQ](docs/Catesta-FAQ.md)**
 
 ## Author
 

--- a/actions_bootstrap.ps1
+++ b/actions_bootstrap.ps1
@@ -21,12 +21,12 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.5.7'
+            ModuleVersion = '5.6.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.18.3'
+            ModuleVersion = '1.19.1'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/docs/Catesta-AWS.md
+++ b/docs/Catesta-AWS.md
@@ -40,7 +40,7 @@ Scaffolds a new PowerShell module project intended for CI/CD workflow using [AWS
         | buildspec_pwsh_windows.yml  | WINDOWS_CONTAINER  | pwsh (1) |
         | buildspec_pwsh_linux.yml  | LINUX_CONTAINER  | pwsh  |
 
-        * (1)PowerShell 6.2.3 will be downloaded, installed, and all build tasks will run under the context of pwsh*
+        * (1)PowerShell 7 will be downloaded, installed, and all build tasks will run under the context of pwsh*
 1. Create your CodeBuild project in your AWS account. You can do this manually, or use the generated CloudFormation template (recommended).
     * **GitHub**
       * The generated CFN template will guide you through the process. You will need a SEPERATE CodeBuild for each build type. So, if you wanted to build against all three platforms, you would deploy the template three times, specifying the desired buildspec for each stack deployment.

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 0.8.12
+Help Version: 0.9.0
 Locale: en-US
 ---
 

--- a/src/Catesta.build.ps1
+++ b/src/Catesta.build.ps1
@@ -112,7 +112,7 @@ Add-BuildTask Clean {
 Add-BuildTask ValidateRequirements {
     #running at least powershell 5?
     Write-Build White '      Verifying at least PowerShell 5...'
-    Assert-Build ($PSVersionTable.PSVersion.Major.ToString() -ge '5') 'At least Powershell 6 is required for this build to function properly'
+    Assert-Build ($PSVersionTable.PSVersion.Major.ToString() -ge '5') 'At least Powershell 5 is required for this build to function properly'
     Write-Build Green '      ...Verification Complete!'
 }#ValidateRequirements
 
@@ -165,14 +165,14 @@ Add-BuildTask AnalyzeTests -After Analyze {
 #Synopsis: Analyze scripts to verify if they adhere to desired coding format (Stroustrup / OTBS / Allman)
 Add-BuildTask FormattingCheck {
     $scriptAnalyzerParams = @{
-        Setting      = 'CodeFormattingStroustrup'
+        Setting     = 'CodeFormattingStroustrup'
         ExcludeRule = @(
             'PSUseConsistentIndentation',
             'PSUseConsistentWhitespace'
         )
         # ExcludeRule = 'PSUseConsistentWhitespace'
-        Recurse      = $true
-        Verbose      = $false
+        Recurse     = $true
+        Verbose     = $false
     }
 
     Write-Build White '      Performing script formatting checks...'
@@ -190,21 +190,25 @@ Add-BuildTask FormattingCheck {
 #Synopsis: Invokes all Pester Unit Tests in the Tests\Unit folder (if it exists)
 Add-BuildTask Test {
     $codeCovPath = "$script:ArtifactsPath\ccReport\"
+    $testOutPutPath = "$script:ArtifactsPath\testOutput\"
     if (-not(Test-Path $codeCovPath)) {
         New-Item -Path $codeCovPath -ItemType Directory | Out-Null
     }
+    if (-not(Test-Path $testOutPutPath)) {
+        New-Item -Path $testOutPutPath -ItemType Directory | Out-Null
+    }
     if (Test-Path -Path $script:UnitTestsPath) {
         $invokePesterParams = @{
-            Path                   = 'Tests\Unit'
-            Strict                 = $true
-            PassThru               = $true
-            Verbose                = $false
-            EnableExit             = $false
-            CodeCoverage           = "$ModuleName\*\*.ps1"
-            CodeCoverageOutputFile = "$codeCovPath\CodeCoverage.xml"
-            # CodeCoverage                 = "$ModuleName\*\*.ps1"
-            # CodeCoverageOutputFile       = "$codeCovPath\codecoverage.xml"
-            # CodeCoverageOutputFileFormat = 'JaCoCo'
+            Path                         = 'Tests\Unit'
+            Strict                       = $true
+            PassThru                     = $true
+            Verbose                      = $false
+            EnableExit                   = $false
+            CodeCoverage                 = "$ModuleName\*\*.ps1"
+            CodeCoverageOutputFile       = "$codeCovPath\CodeCoverage.xml"
+            CodeCoverageOutputFileFormat = 'JaCoCo'
+            OutputFile                   = "$testOutPutPath\PesterTests.xml"
+            OutputFormat                 = 'JUnitXml'
         }
 
         Write-Build White '      Performing Pester Unit Tests...'
@@ -304,7 +308,7 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
         }
     }
     # Replace each missing element we need for a proper generic module page .md file
-    $ModulePageFileContent = Get-Content -raw $ModulePage
+    $ModulePageFileContent = Get-Content -Raw $ModulePage
     $ModulePageFileContent = $ModulePageFileContent -replace '{{Manually Enter Description Here}}', $script:ModuleDescription
     $Script:FunctionsToExport | ForEach-Object {
         Write-Build DarkGray "             Updating definition for the following function: $($_)"

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.8.12'
+    ModuleVersion     = '0.9.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -58,15 +58,15 @@
         },
         @{
             ModuleName    = 'Pester'
-            ModuleVersion = '4.9.0'
+            ModuleVersion = '4.10.1'
         },
         @{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.5.5'
+            ModuleVersion = '5.6.1'
         },
         @{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.18.0'
+            ModuleVersion = '1.19.1'
         },
         @{
             ModuleName      = 'platyPS'
@@ -118,44 +118,44 @@
         PSData = @{
 
             # Tags applied to this module. These help with module discovery in online galleries.
-            Tags = @(
-                'Module',
-                'Modules',
-                'Plaster',
-                'Template',
-                'Project',
-                'Scaffold',
-                'Cross-Platform',
-                'CrossPlatform',
-                'MultiCloud',
-                'PowerShell',
-                'pwsh',
-                'CICD',
-                'Windows',
-                'Linux',
-                'MacOS',
+            Tags                     = @(
+                'Actions',
+                'AppVeyor',
+                'AWS',
+                'AWS-CodeBuild',
                 'Azure',
                 'Azure-DevOps',
-                'AWS',
+                'CICD',
                 'CodeBuild',
-                'AWS-CodeBuild',
-                'AppVeyor',
+                'Cross-Platform',
+                'CrossPlatform',
                 'GitHub',
-                'Actions',
-                'GitHub-Actions'
+                'GitHub-Actions',
+                'Linux',
+                'MacOS',
+                'Module',
+                'Modules',
+                'MultiCloud',
+                'Plaster',
+                'PowerShell',
+                'Project',
+                'pwsh',
+                'Scaffold',
+                'Template',
+                'Windows'
             )
 
             # A URL to the license for this module.
             # LicenseUri = 'https://github.com/techthoughts2/Catesta/blob/master/LICENSE'
 
             # A URL to the main website for this project.
-            ProjectUri = 'https://github.com/techthoughts2/Catesta'
+            ProjectUri               = 'https://github.com/techthoughts2/Catesta'
 
             # A URL to an icon representing this module.
-            IconUri = 'https://github.com/techthoughts2/Catesta/raw/master/media/CatestaIcon.png'
+            IconUri                  = 'https://github.com/techthoughts2/Catesta/raw/master/media/CatestaIcon.png'
 
             # ReleaseNotes of this module
-            ReleaseNotes = 'https://github.com/techthoughts2/Catesta/blob/master/.github/CHANGELOG.md'
+            ReleaseNotes             = 'https://github.com/techthoughts2/Catesta/blob/master/.github/CHANGELOG.md'
 
             # Prerelease string of this module
             # Prerelease = ''
@@ -167,7 +167,7 @@
             # ExternalModuleDependencies = @()
 
             #https://github.com/PowerShell/Plaster/tree/master/examples/TemplateModule
-            Extensions   = @(
+            Extensions               = @(
                 @{
                     Module         = 'Plaster'
                     MinimumVersion = '1.1.3'

--- a/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildCC.yml
+++ b/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildCC.yml
@@ -35,6 +35,7 @@ Parameters:
   #   Default: WINDOWS_CONTAINER
   #   Description: The type of build environment.
   #   AllowedValues:
+  #     - WINDOWS_SERVER_2019_CONTAINER
   #     - WINDOWS_CONTAINER
   #     - LINUX_CONTAINER
 
@@ -54,8 +55,9 @@ Parameters:
   #  Default : aws/codebuild/windows-base:1.0
   #  Description: The size of the CodeBuild instance. (Windows Containers do NOT support small)
   #  AllowedValues:
-  #    - aws/codebuild/windows-base:1.0
-  #    - aws/codebuild/dot-net:core-2.1
+  #    - aws/codebuild/windows-base:2019-1.0
+  #    - aws/codebuild/windows-base:2.0
+  #    - aws/codebuild/standard:4.0
 
   # BuildSpecFile:
   #   Type: String
@@ -188,6 +190,22 @@ Resources:
                   - "s3:*"
                 Resource:
                   - "*"
+        - PolicyName: CBReportAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:CreateReport
+                  - codebuild:CreateReportGroup
+                  - codebuild:UpdateReportGroup
+                  - codebuild:UpdateReport
+                  - codebuild:DeleteReportGroup
+                  - codebuild:DeleteReport
+                  - codebuild:BatchPutCodeCoverages
+                  - codebuild:BatchPutTestCases
+                Resource:
+                  - !Sub "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/<%=$PLASTER_PARAM_ModuleName%>*"
 
   # IAM Role for invoking the CodeBuild project
   # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
@@ -308,8 +326,9 @@ Resources:
       Description: !Ref CodeCommitRepositoryDescription
       Environment:
         ComputeType: BUILD_GENERAL1_MEDIUM
-        Image: aws/codebuild/windows-base:2.0
-        Type: WINDOWS_CONTAINER
+        Image: aws/codebuild/windows-base:2019-1.0
+        Type: WINDOWS_SERVER_2019_CONTAINER
+        # Type: WINDOWS_CONTAINER
         EnvironmentVariables:
           - Name: master_bucket
             Value: placeholder
@@ -349,8 +368,9 @@ Resources:
       Description: !Ref CodeCommitRepositoryDescription
       Environment:
         ComputeType: BUILD_GENERAL1_MEDIUM
-        Image: aws/codebuild/windows-base:2.0
-        Type: WINDOWS_CONTAINER
+        Image: aws/codebuild/windows-base:2019-1.0
+        Type: WINDOWS_SERVER_2019_CONTAINER
+        # Type: WINDOWS_CONTAINER
         EnvironmentVariables:
           - Name: master_bucket
             Value: placeholder

--- a/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildCC.yml
+++ b/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildCC.yml
@@ -391,7 +391,7 @@ Resources:
       Description: !Ref CodeCommitRepositoryDescription
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:3.0
+        Image: aws/codebuild/standard:4.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: master_bucket

--- a/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildGit.yml
+++ b/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildGit.yml
@@ -41,6 +41,7 @@ Parameters:
   #  Default: WINDOWS_CONTAINER
   #  Description: The type of build environment.
   #  AllowedValues:
+  #    - WINDOWS_SERVER_2019_CONTAINER
   #    - WINDOWS_CONTAINER
   #    - LINUX_CONTAINER
 
@@ -60,8 +61,9 @@ Parameters:
   #  Default : aws/codebuild/windows-base:1.0
   #  Description: The size of the CodeBuild instance. (Windows Containers do NOT support small)
   #  AllowedValues:
-  #    - aws/codebuild/windows-base:1.0
-  #    - aws/codebuild/dot-net:core-2.1
+  #    - aws/codebuild/windows-base:2019-1.0
+  #    - aws/codebuild/windows-base:2.0
+  #    - aws/codebuild/standard:4.0
 
   # BuildSpecFile:
   #   Type: String
@@ -190,6 +192,22 @@ Resources:
                   - s3:GetObjectVersion
                 Resource:
                   - arn:aws:s3:::codepipeline-${AWS::Region}-*
+        - PolicyName: CBReportAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:CreateReport
+                  - codebuild:CreateReportGroup
+                  - codebuild:UpdateReportGroup
+                  - codebuild:UpdateReport
+                  - codebuild:DeleteReportGroup
+                  - codebuild:DeleteReport
+                  - codebuild:BatchPutCodeCoverages
+                  - codebuild:BatchPutTestCases
+                Resource:
+                  - !Sub "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/<%=$PLASTER_PARAM_ModuleName%>*"
 
 <%
     if ($PLASTER_PARAM_Options -eq 'ps') {
@@ -207,9 +225,10 @@ Resources:
       Environment:
         #ComputeType: !Ref CodeBuildComputeType
         ComputeType: BUILD_GENERAL1_MEDIUM
-        Image: "aws/codebuild/windows-base:2.0"
-        #Type: !Ref CodeBuildEnvironment
-        Type: WINDOWS_CONTAINER
+        Image: "aws/codebuild/windows-base:2019-1.0"
+        # Type: !Ref CodeBuildEnvironment
+        Type: WINDOWS_SERVER_2019_CONTAINER
+        # Type: WINDOWS_CONTAINER
       Name: !Join
         - "-"
         - - !Ref ProjectName
@@ -253,9 +272,10 @@ Resources:
       Environment:
         #ComputeType: !Ref CodeBuildComputeType
         ComputeType: BUILD_GENERAL1_MEDIUM
-        Image: "aws/codebuild/windows-base:2.0"
-        #Type: !Ref CodeBuildEnvironment
-        Type: WINDOWS_CONTAINER
+        Image: "aws/codebuild/windows-base:2019-1.0"
+        Type: WINDOWS_SERVER_2019_CONTAINER
+        # Type: !Ref CodeBuildEnvironment
+        # Type: WINDOWS_CONTAINER
       Name: !Join
         - "-"
         - - !Ref ProjectName

--- a/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildGit.yml
+++ b/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildGit.yml
@@ -299,7 +299,7 @@ Resources:
       Environment:
         #ComputeType: !Ref CodeBuildComputeType
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: "aws/codebuild/standard:3.0"
+        Image: "aws/codebuild/standard:4.0"
         #Type: !Ref CodeBuildEnvironment
         Type: LINUX_CONTAINER
       Name: !Join

--- a/src/Catesta/Resources/AWS/buildspec_powershell_windows.yml
+++ b/src/Catesta/Resources/AWS/buildspec_powershell_windows.yml
@@ -1,6 +1,8 @@
 # This is a simple CodeBuild build file for PowerShell.
 # - pre_build step will ensure the Module Name / Version has not previously been built for production (plans to add this at a later time)
 # - build step will perform Clean, ValidateRequirements, Analyze, Test, CreateHelp, Build, Archive
+# https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#runtime-versions-buildspec-file
+# https://docs.aws.amazon.com/codebuild/latest/userguide/test-reporting.html
 
 version: 0.2
 
@@ -11,9 +13,9 @@ phases:
       - powershell -command '.\install_modules.ps1'
   pre_build:
     commands:
-      - powershell -command '$PSVersionTable'
       # - powershell -command 'New-Item -Path C:\Test -ItemType Directory | Out-Null'
       # - powershell -command 'Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.Settings.ps1 -Task ValidateUniqueModuleVersion'
+      - powershell -command '$PSVersionTable'
   build:
     commands:
       - powershell -command 'Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1'
@@ -21,3 +23,13 @@ artifacts:
   files:
     - '**/*'
   base-directory: 'src\Archive'
+reports:
+  PesterTestReport:
+    files:
+      - '**/*'
+    file-format: NunitXml
+    base-directory: 'src\Artifacts\testOutput'
+  CodeCoverageReport:
+    files:
+      - 'src\Artifacts\ccReport\CodeCoverage.xml'
+    file-format: 'JaCoCoXml'

--- a/src/Catesta/Resources/AWS/buildspec_pwsh_linux.yml
+++ b/src/Catesta/Resources/AWS/buildspec_pwsh_linux.yml
@@ -2,6 +2,8 @@
 # - pre_build step will ensure the Module Name / Version has not previously been built for production (plans to add this at a later time)
 # - build step will perform Clean, ValidateRequirements, Analyze, Test, CreateHelp, Build, Archive
 # https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#runtime-versions-buildspec-file
+# https://docs.aws.amazon.com/codebuild/latest/userguide/test-reporting.html
+
 version: 0.2
 
 phases:
@@ -13,9 +15,9 @@ phases:
       - pwsh -command './install_modules.ps1'
   pre_build:
     commands:
-      - pwsh -command '$PSVersionTable'
       # - pwsh -command 'New-Item -Path /Test -ItemType Directory | Out-Null'
       # - pwsh -command 'Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.Settings.ps1 -Task ValidateUniqueModuleVersion'
+      - pwsh -command '$PSVersionTable'
   build:
     commands:
       - pwsh -command 'Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1'
@@ -23,3 +25,13 @@ artifacts:
   files:
     - '**/*'
   base-directory: 'src/Archive'
+reports:
+  PesterTestReport:
+    files:
+      - '**/*'
+    file-format: NunitXml
+    base-directory: 'src/Artifacts/testOutput'
+  CodeCoverageReport:
+    files:
+      - 'src/Artifacts/ccReport/CodeCoverage.xml'
+    file-format: 'JaCoCoXml'

--- a/src/Catesta/Resources/AWS/buildspec_pwsh_linux.yml
+++ b/src/Catesta/Resources/AWS/buildspec_pwsh_linux.yml
@@ -7,7 +7,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      dotnet: 3.0
+      dotnet: 3.1
     commands:
       - pwsh -command './configure_aws_credential.ps1'
       - pwsh -command './install_modules.ps1'

--- a/src/Catesta/Resources/AWS/buildspec_pwsh_windows.yml
+++ b/src/Catesta/Resources/AWS/buildspec_pwsh_windows.yml
@@ -1,6 +1,8 @@
 # This is a simple CodeBuild build file for PowerShell.
 # - pre_build step will ensure the Module Name / Version has not previously been built for production (plans to add this at a later time)
 # - build step will perform Clean, ValidateRequirements, Analyze, Test, CreateHelp, Build, Archive
+# https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#runtime-versions-buildspec-file
+# https://docs.aws.amazon.com/codebuild/latest/userguide/test-reporting.html
 
 version: 0.2
 
@@ -8,18 +10,29 @@ phases:
   install:
     commands:
       - powershell -command '.\configure_aws_credential.ps1'
-      # - aws s3 cp s3://ps-invoke-modules/PowerShell-7.0.0-win-x64.msi PowerShell-7.0.0-win-x64.msi --quiet
-      - powershell -command '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;$url = """https://github.com/PowerShell/PowerShell/releases/download/v7.0.0/PowerShell-7.0.0-win-x64.msi""";$output = """$env:CODEBUILD_SRC_DIR\PowerShell-7.0.0-win-x64.msi""";Invoke-WebRequest -Uri $url -OutFile $output -ErrorAction Stop;if (-not(Test-Path $output)) {throw """PSCore failed to DL"""}'
-      - powershell -command "Start-Process $env:CODEBUILD_SRC_DIR\PowerShell-7.0.0-win-x64.msi -ArgumentList '/qn /norestart' -Wait"
+      # - aws s3 cp s3://ps-invoke-modules/PowerShell-7.0.3-win-x64.msi PowerShell-7.0.3-win-x64.msi --quiet
+      - powershell -command '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;$url = """https://github.com/PowerShell/PowerShell/releases/download/v7.0.3/PowerShell-7.0.3-win-x64.msi""";$output = """$env:CODEBUILD_SRC_DIR\PowerShell-7.0.3-win-x64.msi""";Invoke-WebRequest -Uri $url -OutFile $output -ErrorAction Stop;if (-not(Test-Path $output)) {throw """PSCore failed to DL"""}'
+      - powershell -command "Start-Process $env:CODEBUILD_SRC_DIR\PowerShell-7.0.3-win-x64.msi -ArgumentList '/qn /norestart' -Wait"
       - '& "C:\Program Files\PowerShell\7\pwsh.exe" -command ''.\install_modules.ps1'''
   pre_build:
     commands:
       # - powershell -command 'New-Item -Path C:\Test -ItemType Directory | Out-Null'
       # - '& "C:\Program Files\PowerShell\7\pwsh.exe" -command ''Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.Settings.ps1 -Task ValidateUniqueModuleVersion'''
+      - pwsh -command '$PSVersionTable'
   build:
     commands:
-      - '& "C:\Program Files\PowerShell\7\pwsh.exe" -command ''$PSVersionTable;Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1'''
+      - '& "C:\Program Files\PowerShell\7\pwsh.exe" -command ''Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1'''
 artifacts:
   files:
     - '**/*'
   base-directory: 'src\Archive'
+reports:
+  PesterTestReport:
+    files:
+      - '**/*'
+    file-format: NunitXml
+    base-directory: 'src\Artifacts\testOutput'
+  CodeCoverageReport:
+    files:
+      - 'src\Artifacts\ccReport\CodeCoverage.xml'
+    file-format: 'JaCoCoXml'

--- a/src/Catesta/Resources/AWS/install_modules.ps1
+++ b/src/Catesta/Resources/AWS/install_modules.ps1
@@ -50,19 +50,25 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.5.7'
+            ModuleVersion = '5.6.1'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.18.3'
+            ModuleVersion = '1.19.1'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'platyPS'
             ModuleVersion = '0.12.0'
+            BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
+            KeyPrefix     = ''
+        }))
+$null = $modulesToInstall.Add(([PSCustomObject]@{
+            ModuleName    = 'AWS.Tools.Common'
+            ModuleVersion = '4.1.0.0'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))
@@ -163,7 +169,7 @@ else {
                 Install-Module $module.ModuleName -RequiredVersion $module.ModuleVersion -Repository PSGallery -Force -SkipPublisherCheck -ErrorAction Stop
             }
             else {
-                Install-Module $module.ModuleName -RequiredVersion $module.ModuleVersion -Repository PSGallery -Confirm:$false -Force -ErrorAction Stop
+                Install-Module $module.ModuleName -RequiredVersion $module.ModuleVersion -Repository PSGallery -Confirm:$false -Force -SkipPublisherCheck -ErrorAction Stop
             }
         }
         catch {

--- a/src/Catesta/Resources/AWS/plasterManifest.xml
+++ b/src/Catesta/Resources/AWS/plasterManifest.xml
@@ -70,7 +70,7 @@
     <file source='' destination='src\${PLASTER_PARAM_ModuleName}'/>
     <file source='' destination='src\${PLASTER_PARAM_ModuleName}\Public'/>
     <file source='' destination='src\${PLASTER_PARAM_ModuleName}\Private'/>
-    <file source='..\editor\VSCode\tasks.json' destination='.vscode\tasks.json' />
+    <templateFile source='..\editor\VSCode\tasks.json' destination='.vscode\tasks.json' />
     <file source='..\editor\VSCode\extensions.json' destination='.vscode\extensions.json' />
     <templateFile source='..\editor\VSCode\settings.json' destination='.vscode\settings.json' />
 
@@ -125,7 +125,8 @@ Your new PowerShell module project '$PLASTER_PARAM_ModuleName' has been created.
 
     <message>
 Several Pester tests have been created to validate various components of the module.  Add additional tests to the test directory.
-You can run the Pester tests in your project by executing the 'test' task.  Press Ctrl+P, then type 'task test'.
+If using VSCode you can run the Pester tests in your project by executing the 'test' task.  Press Ctrl+P, then type 'task TestLocal'.
+Other build related tasks are also available. Press Ctrl+P, then type 'task' and press space. You will see a list of available build tasks.
     </message>
 
     <message>

--- a/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
@@ -16,12 +16,12 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.5.7'
+            ModuleVersion = '5.6.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.18.3'
+            ModuleVersion = '1.19.1'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/src/Catesta/Resources/AppVeyor/appveyor.yml
+++ b/src/Catesta/Resources/AppVeyor/appveyor.yml
@@ -1,6 +1,7 @@
 version: 1.0.{build}
 
 # https://www.appveyor.com/docs/build-configuration/
+# https://www.appveyor.com/docs/build-environment/
 # https://www.appveyor.com/docs/build-configuration/#specializing-matrix-job-configuration
 # https://www.appveyor.com/docs/appveyor-yml/
 
@@ -56,7 +57,7 @@ for:
   install:
     - ps: . .\actions_bootstrap.ps1
   build_script:
-    - ps: Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
+    - ps: Remove-Module Pester -ErrorAction SilentlyContinue;Import-Module Pester -RequiredVersion 4.10.1;Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
 '@
 }
 %>
@@ -73,3 +74,11 @@ build_script:
 '@
 }
 %>
+
+artifacts:
+  - path: src/Artifacts/testOutput/PesterTests.xml
+    name: PesterTestResults
+  - path: src/Artifacts/ccReport/CodeCoverage.xml
+    name: CodeCoverageResults
+  - path: src/Archive/*.zip
+    name: BuildArtifact

--- a/src/Catesta/Resources/AppVeyor/plasterManifest.xml
+++ b/src/Catesta/Resources/AppVeyor/plasterManifest.xml
@@ -64,7 +64,7 @@
     <file source='' destination='src\${PLASTER_PARAM_ModuleName}'/>
     <file source='' destination='src\${PLASTER_PARAM_ModuleName}\Public'/>
     <file source='' destination='src\${PLASTER_PARAM_ModuleName}\Private'/>
-    <file source='..\editor\VSCode\tasks.json' destination='.vscode\tasks.json' />
+    <templateFile source='..\editor\VSCode\tasks.json' destination='.vscode\tasks.json' />
     <file source='..\editor\VSCode\extensions.json' destination='.vscode\extensions.json' />
     <templateFile source='..\editor\VSCode\settings.json' destination='.vscode\settings.json' />
 
@@ -112,7 +112,8 @@ Your new PowerShell module project '$PLASTER_PARAM_ModuleName' has been created.
 
     <message>
 Several Pester tests have been created to validate various components of the module.  Add additional tests to the test directory.
-You can run the Pester tests in your project by executing the 'test' task.  Press Ctrl+P, then type 'task test'.
+If using VSCode you can run the Pester tests in your project by executing the 'test' task.  Press Ctrl+P, then type 'task TestLocal'.
+Other build related tasks are also available. Press Ctrl+P, then type 'task' and press space. You will see a list of available build tasks.
     </message>
 
     <message>

--- a/src/Catesta/Resources/Azure/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/Azure/actions_bootstrap.ps1
@@ -16,12 +16,12 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.5.7'
+            ModuleVersion = '5.6.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.18.3'
+            ModuleVersion = '1.19.1'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/src/Catesta/Resources/Azure/azure-pipelines.yml
+++ b/src/Catesta/Resources/Azure/azure-pipelines.yml
@@ -3,6 +3,8 @@ jobs:
   # https://docs.microsoft.com/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema
   # https://docs.microsoft.com/azure/devops/pipelines/agents/hosted?view=azure-devops#use-a-microsoft-hosted-agent
   # https://docs.microsoft.com/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+  # https://docs.microsoft.com/azure/devops/pipelines/tasks/test/publish-code-coverage-results?view=azure-devops
+  # https://docs.microsoft.com/azure/devops/pipelines/artifacts/build-artifacts?view=azure-devops&tabs=yaml
 <%
 If ($PLASTER_PARAM_Options -eq 'windows') {
 @'
@@ -13,13 +15,28 @@ If ($PLASTER_PARAM_Options -eq 'windows') {
     - powershell: |
         $PSVersionTable
         .\actions_bootstrap.ps1
+        Remove-Module Pester -ErrorAction SilentlyContinue
+        Import-Module Pester -RequiredVersion 4.10.1
         Invoke-Build -File $(Build.SourcesDirectory)\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
       displayName: 'Build and Test - Windows PowerShell'
     - task: PublishTestResults@2
       inputs:
         testRunner: 'NUnit'
-        testResultsFiles: '**/out/testResults.xml'
+        testResultsFiles: '**\Artifacts\testOutput\PesterTests.xml'
         testRunTitle: 'ps_winLatest'
+        failTaskOnFailedTests: true
+      displayName: "Publish Unit Test Results - Windows PowerShell"
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        summaryFileLocation: '**\Artifacts\ccReport\CodeCoverage.xml'
+        pathToSources: '$(System.DefaultWorkingDirectory)\src\Artifacts\ccReport'
+        failIfCoverageEmpty: false
+      displayName: "Publish Unit Test Code Coverage - Windows PowerShell"
+      condition: and(in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed'), eq(variables['System.PullRequest.IsFork'], false))
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: '$(System.DefaultWorkingDirectory)\src\Archive'
+        artifactName: <%=$PLASTER_PARAM_ModuleName%>-Archive
 '@
 }
 %>
@@ -39,9 +56,21 @@ If ($PLASTER_PARAM_Options -eq 'pwshcore') {
     - task: PublishTestResults@2
       inputs:
         testRunner: 'NUnit'
-        testResultsFiles: '**/out/testResults.xml'
+        testResultsFiles: '**\Artifacts\testOutput\PesterTests.xml'
         testRunTitle: 'pwsh_winLatest'
-      # displayName: 'Publish Test Results'
+        failTaskOnFailedTests: true
+      displayName: "Publish Unit Test Results - Windows pwsh"
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        summaryFileLocation: '**\Artifacts\ccReport\CodeCoverage.xml'
+        pathToSources: '$(System.DefaultWorkingDirectory)\src\Artifacts\ccReport'
+        failIfCoverageEmpty: false
+      displayName: "Publish Unit Test Code Coverage - Windows pwsh"
+      condition: and(in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed'), eq(variables['System.PullRequest.IsFork'], false))
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: '$(System.DefaultWorkingDirectory)\src\Archive'
+        artifactName: <%=$PLASTER_PARAM_ModuleName%>-Archive
 '@
 }
 %>
@@ -63,9 +92,21 @@ If ($PLASTER_PARAM_Options -eq 'linux') {
     - task: PublishTestResults@2
       inputs:
         testRunner: 'NUnit'
-        testResultsFiles: '**/out/testResults.xml'
+        testResultsFiles: '**/Artifacts/testOutput/PesterTests.xml'
         testRunTitle: 'pwsh_ubuntuLatest'
-      # displayName: 'Publish Test Results'
+        failTaskOnFailedTests: true
+      displayName: "Publish Unit Test Results - Linux"
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        summaryFileLocation: '**/Artifacts/ccReport/CodeCoverage.xml'
+        pathToSources: '$(System.DefaultWorkingDirectory)/src/Artifacts/ccReport'
+        failIfCoverageEmpty: false
+      displayName: "Publish Unit Test Code Coverage - Linux"
+      condition: and(in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed'), eq(variables['System.PullRequest.IsFork'], false))
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: '$(System.DefaultWorkingDirectory)/src/Archive'
+        artifactName: <%=$PLASTER_PARAM_ModuleName%>-Archive
 '@
 }
 %>
@@ -84,13 +125,25 @@ If ($PLASTER_PARAM_Options -eq 'macos') {
       displayName: 'Install PowerShell Core'
     - script: |
         pwsh -c '$PSVersionTable;.\actions_bootstrap.ps1;Invoke-Build -File $(Build.SourcesDirectory)/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'
-      displayName: 'Build and Test'
+      displayName: 'Build and Test - macOS'
     - task: PublishTestResults@2
       inputs:
         testRunner: 'NUnit'
-        testResultsFiles: '**/out/testResults.xml'
+        testResultsFiles: '**/Artifacts/testOutput/PesterTests.xml'
         testRunTitle: 'pwsh_macOSLatest'
-      # displayName: 'Publish Test Results'
+        failTaskOnFailedTests: true
+      displayName: "Publish Unit Test Results - macOS"
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        summaryFileLocation: '**/Artifacts/ccReport/CodeCoverage.xml'
+        pathToSources: '$(System.DefaultWorkingDirectory)/src/Artifacts/ccReport'
+        failIfCoverageEmpty: false
+      displayName: "Publish Unit Test Code Coverage - macOS"
+      condition: and(in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed'), eq(variables['System.PullRequest.IsFork'], false))
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: '$(System.DefaultWorkingDirectory)/src/Archive'
+        artifactName: <%=$PLASTER_PARAM_ModuleName%>-Archive
 '@
 }
 %>

--- a/src/Catesta/Resources/Azure/plasterManifest.xml
+++ b/src/Catesta/Resources/Azure/plasterManifest.xml
@@ -64,7 +64,7 @@
     <file source='' destination='src\${PLASTER_PARAM_ModuleName}'/>
     <file source='' destination='src\${PLASTER_PARAM_ModuleName}\Public'/>
     <file source='' destination='src\${PLASTER_PARAM_ModuleName}\Private'/>
-    <file source='..\editor\VSCode\tasks.json' destination='.vscode\tasks.json' />
+    <templateFile source='..\editor\VSCode\tasks.json' destination='.vscode\tasks.json' />
     <file source='..\editor\VSCode\extensions.json' destination='.vscode\extensions.json' />
     <templateFile source='..\editor\VSCode\settings.json' destination='.vscode\settings.json' />
 
@@ -112,7 +112,8 @@ Your new PowerShell module project '$PLASTER_PARAM_ModuleName' has been created.
 
     <message>
 Several Pester tests have been created to validate various components of the module.  Add additional tests to the test directory.
-You can run the Pester tests in your project by executing the 'test' task.  Press Ctrl+P, then type 'task test'.
+If using VSCode you can run the Pester tests in your project by executing the 'test' task.  Press Ctrl+P, then type 'task TestLocal'.
+Other build related tasks are also available. Press Ctrl+P, then type 'task' and press space. You will see a list of available build tasks.
     </message>
 
     <message>

--- a/src/Catesta/Resources/Editor/VSCode/tasks.json
+++ b/src/Catesta/Resources/Editor/VSCode/tasks.json
@@ -45,14 +45,90 @@
     // Associate with test task runner
     "tasks": [
         {
-            "label": "Test",
+            "label": "PesterTest",
             "type": "shell",
             "group": {
                 "kind": "test",
                 "isDefault": true
             },
             "problemMatcher": [ "$pester" ],
-            "command": "Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true}"
+            "command": "Invoke-Pester '${workspaceFolder}/src/Tests/Unit' -PesterOption @{IncludeVSCodeMarker=$true}",
+        }
+        {
+            "label": ".",
+            "type": "shell",
+            "problemMatcher": "$msCompile",
+            "command": "$PSVersionTable;Invoke-Build -Task . -File '${workspaceFolder}/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "TestLocal",
+            "type": "shell",
+            "problemMatcher": "$msCompile",
+            "command": "Invoke-Build -Task TestLocal -File '${workspaceFolder}/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'"
+        },
+        {
+            "label": "HelpLocal",
+            "type": "shell",
+            "problemMatcher": "$msCompile",
+            "command": "Invoke-Build -Task HelpLocal -File '${workspaceFolder}/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'"
+        },
+        {
+            "label": "Clean",
+            "type": "shell",
+            "problemMatcher": "$msCompile",
+            "command": "Invoke-Build -Task Clean -File '${workspaceFolder}/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'"
+        },
+        {
+            "label": "ValidateRequirements",
+            "type": "shell",
+            "problemMatcher": "$msCompile",
+            "command": "Invoke-Build -Task ValidateRequirements -File '${workspaceFolder}/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'"
+        },
+        {
+            "label": "Analyze",
+            "type": "shell",
+            "problemMatcher": "$msCompile",
+            "command": "Invoke-Build -Task Analyze -File '${workspaceFolder}/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'"
+        },
+        {
+            "label": "AnalyzeTests",
+            "type": "shell",
+            "problemMatcher": "$msCompile",
+            "command": "Invoke-Build -Task AnalyzeTests -File '${workspaceFolder}/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'"
+        },
+        {
+            "label": "FormattingCheck",
+            "type": "shell",
+            "problemMatcher": "$msCompile",
+            "command": "Invoke-Build -Task FormattingCheck -File '${workspaceFolder}/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'"
+        },
+        {
+            "label": "Test",
+            "type": "shell",
+            "problemMatcher": "$msCompile",
+            "command": "Invoke-Build -Task Test -File '${workspaceFolder}/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'"
+        },
+        {
+            "label": "DevCC",
+            "type": "shell",
+            "problemMatcher": "$msCompile",
+            "command": "Invoke-Build -Task DevCC -File '${workspaceFolder}/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'"
+        },
+        {
+            "label": "Build",
+            "type": "shell",
+            "problemMatcher": "$msCompile",
+            "command": "Invoke-Build -Task Build -File '${workspaceFolder}/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'"
+        },
+        {
+            "label": "InfraTest",
+            "type": "shell",
+            "problemMatcher": "$msCompile",
+            "command": "Invoke-Build -Task InfraTest -File '${workspaceFolder}/src/<%=$PLASTER_PARAM_ModuleName%>.build.ps1'"
         }
 	]
 }

--- a/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
@@ -16,12 +16,12 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.5.7'
+            ModuleVersion = '5.6.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.18.3'
+            ModuleVersion = '1.19.1'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/src/Catesta/Resources/GitHubActions/plasterManifest.xml
+++ b/src/Catesta/Resources/GitHubActions/plasterManifest.xml
@@ -64,7 +64,7 @@
     <file source='' destination='src\${PLASTER_PARAM_ModuleName}'/>
     <file source='' destination='src\${PLASTER_PARAM_ModuleName}\Public'/>
     <file source='' destination='src\${PLASTER_PARAM_ModuleName}\Private'/>
-    <file source='..\editor\VSCode\tasks.json' destination='.vscode\tasks.json' />
+    <templateFile source='..\editor\VSCode\tasks.json' destination='.vscode\tasks.json' />
     <file source='..\editor\VSCode\extensions.json' destination='.vscode\extensions.json' />
     <templateFile source='..\editor\VSCode\settings.json' destination='.vscode\settings.json' />
 
@@ -115,7 +115,8 @@ Your new PowerShell module project '$PLASTER_PARAM_ModuleName' has been created.
 
     <message>
 Several Pester tests have been created to validate various components of the module.  Add additional tests to the test directory.
-You can run the Pester tests in your project by executing the 'test' task.  Press Ctrl+P, then type 'task test'.
+If using VSCode you can run the Pester tests in your project by executing the 'test' task.  Press Ctrl+P, then type 'task TestLocal'.
+Other build related tasks are also available. Press Ctrl+P, then type 'task' and press space. You will see a list of available build tasks.
     </message>
 
     <message>

--- a/src/Catesta/Resources/GitHubActions/workflows/wf_Linux.yml
+++ b/src/Catesta/Resources/GitHubActions/workflows/wf_Linux.yml
@@ -3,6 +3,7 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
+# https://github.com/actions/upload-artifact#where-does-the-upload-go
 name: ActionsTest-Linux-Build
 on: [push, pull_request]
 jobs:
@@ -12,7 +13,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - name: Check out repository
+      uses: actions/checkout@v2
     - name: Display the path
       shell: pwsh
       run: echo ${env:PATH}
@@ -25,3 +27,15 @@ jobs:
     - name: Test and Build
       shell: pwsh
       run: Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
+    - name: Upload pester results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pester-results
+        path: ./src/Artifacts/testOutput
+        if-no-files-found: warn
+    - name: Upload zip module archive build
+      uses: actions/upload-artifact@v2
+      with:
+        name: zip-archive
+        path: ./src/Archive
+        if-no-files-found: warn

--- a/src/Catesta/Resources/GitHubActions/workflows/wf_MacOS.yml
+++ b/src/Catesta/Resources/GitHubActions/workflows/wf_MacOS.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - name: Check out repository
+      uses: actions/checkout@v2
     - name: Display the path
       shell: pwsh
       run: echo ${env:PATH}
@@ -25,3 +26,15 @@ jobs:
     - name: Test and Build
       shell: pwsh
       run: Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
+    - name: Upload pester results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pester-results
+        path: ./src/Artifacts/testOutput
+        if-no-files-found: warn
+    - name: Upload zip module archive build
+      uses: actions/upload-artifact@v2
+      with:
+        name: zip-archive
+        path: ./src/Archive
+        if-no-files-found: warn

--- a/src/Catesta/Resources/GitHubActions/workflows/wf_Windows.yml
+++ b/src/Catesta/Resources/GitHubActions/workflows/wf_Windows.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - name: Check out repository
+      uses: actions/checkout@v2
     - name: Display the path
       shell: powershell
       run: echo ${env:PATH}
@@ -24,4 +25,16 @@ jobs:
       run: ./actions_bootstrap.ps1
     - name: Test and Build
       shell: powershell
-      run: Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
+      run: Remove-Module Pester -ErrorAction SilentlyContinue;Import-Module Pester -RequiredVersion 4.10.1;Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
+    - name: Upload pester results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pester-results
+        path: .\src\Artifacts\testOutput
+        if-no-files-found: warn
+    - name: Upload zip module archive build
+      uses: actions/upload-artifact@v2
+      with:
+        name: zip-archive
+        path: .\src\Archive
+        if-no-files-found: warn

--- a/src/Catesta/Resources/GitHubActions/workflows/wf_Windows_Core.yml
+++ b/src/Catesta/Resources/GitHubActions/workflows/wf_Windows_Core.yml
@@ -3,7 +3,7 @@
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell
 # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions
-name: ActionsTest-Windows-Build
+name: ActionsTest-Windows-pwsh-Build
 on: [push, pull_request]
 jobs:
   test:
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - name: Check out repository
+      uses: actions/checkout@v2
     - name: Display the path
       shell: pwsh
       run: echo ${env:PATH}
@@ -25,3 +26,15 @@ jobs:
     - name: Test and Build
       shell: pwsh
       run: Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
+    - name: Upload pester results
+      uses: actions/upload-artifact@v2
+      with:
+        name: pester-results
+        path: .\src\Artifacts\testOutput
+        if-no-files-found: warn
+    - name: Upload zip module archive build
+      uses: actions/upload-artifact@v2
+      with:
+        name: zip-archive
+        path: .\src\Archive
+        if-no-files-found: warn

--- a/src/Catesta/Resources/Module/src/PSModule.build.ps1
+++ b/src/Catesta/Resources/Module/src/PSModule.build.ps1
@@ -226,21 +226,25 @@ Add-BuildTask FormattingCheck {
 #Synopsis: Invokes all Pester Unit Tests in the Tests\Unit folder (if it exists)
 Add-BuildTask Test {
     $codeCovPath = "$script:ArtifactsPath\ccReport\"
+    $testOutPutPath = "$script:ArtifactsPath\testOutput\"
     if (-not(Test-Path $codeCovPath)) {
         New-Item -Path $codeCovPath -ItemType Directory | Out-Null
     }
+    if (-not(Test-Path $testOutPutPath)) {
+        New-Item -Path $testOutPutPath -ItemType Directory | Out-Null
+    }
     if (Test-Path -Path $script:UnitTestsPath) {
         $invokePesterParams = @{
-            Path                   = 'Tests\Unit'
-            Strict                 = $true
-            PassThru               = $true
-            Verbose                = $false
-            EnableExit             = $false
-            CodeCoverage           = "$ModuleName\*\*.ps1"
-            CodeCoverageOutputFile = "$codeCovPath\CodeCoverage.xml"
-            # CodeCoverage                 = "$ModuleName\*\*.ps1"
-            # CodeCoverageOutputFile       = "$codeCovPath\codecoverage.xml"
-            # CodeCoverageOutputFileFormat = 'JaCoCo'
+            Path                         = 'Tests\Unit'
+            Strict                       = $true
+            PassThru                     = $true
+            Verbose                      = $false
+            EnableExit                   = $false
+            CodeCoverage                 = "$ModuleName\*\*.ps1"
+            CodeCoverageOutputFile       = "$codeCovPath\CodeCoverage.xml"
+            CodeCoverageOutputFileFormat = 'JaCoCo'
+            OutputFile                   = "$testOutPutPath\PesterTests.xml"
+            OutputFormat                 = 'NUnitXML'
         }
 
         Write-Build White '      Performing Pester Unit Tests...'
@@ -338,7 +342,7 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
         }
     }
     # Replace each missing element we need for a proper generic module page .md file
-    $ModulePageFileContent = Get-Content -raw $ModulePage
+    $ModulePageFileContent = Get-Content -Raw $ModulePage
     $ModulePageFileContent = $ModulePageFileContent -replace '{{Manually Enter Description Here}}', $script:ModuleDescription
     $Script:FunctionsToExport | ForEach-Object {
         Write-Build DarkGray "             Updating definition for the following function: $($_)"
@@ -418,7 +422,7 @@ Add-BuildTask Build {
     #$private = "$script:ModuleSourcePath\Private"
     $scriptContent = [System.Text.StringBuilder]::new()
     #$powerShellScripts = Get-ChildItem -Path $script:ModuleSourcePath -Filter '*.ps1' -Recurse
-    $powerShellScripts = Get-ChildItem -Path $script:ArtifactsPath -Recurse | Where-Object {$_.Name -match '^*.ps1$'}
+    $powerShellScripts = Get-ChildItem -Path $script:ArtifactsPath -Recurse | Where-Object { $_.Name -match '^*.ps1$' }
     foreach ($script in $powerShellScripts) {
         $null = $scriptContent.Append((Get-Content -Path $script.FullName -Raw))
         $null = $scriptContent.AppendLine('')

--- a/src/Catesta/Resources/Module/src/Tests/Unit/ExportedFunctions.Tests.ps1
+++ b/src/Catesta/Resources/Module/src/Tests/Unit/ExportedFunctions.Tests.ps1
@@ -13,10 +13,10 @@ Import-Module $PathToManifest -Force
 Describe -Name $ModuleName -Fixture {
 
     $manifestContent = Test-ModuleManifest -Path $PathToManifest
+    $moduleExported = Get-Command -Module $ModuleName | Select-Object -ExpandProperty Name
 
     Context -Name 'Exported Commands' -Fixture {
         $manifestExported = ($manifestContent.ExportedFunctions).Keys
-        $moduleExported = Get-Command -Module $ModuleName | Select-Object -ExpandProperty Name
 
         Context -Name 'Number of commands' -Fixture {
             It -Name 'Exports the same number of public funtions as what is listed in the Module Manifest' -Test {
@@ -47,7 +47,7 @@ Describe -Name $ModuleName -Fixture {
                 }
 
                 It -Name 'Includes at least one example' -Test {
-                    $help.examples.Count | Should -BeGreaterOrEqual 1
+                    $help.examples.example.Count | Should -BeGreaterOrEqual 1
                 }
             }
         }

--- a/src/Tests/Unit/ExportedFunctions.Tests.ps1
+++ b/src/Tests/Unit/ExportedFunctions.Tests.ps1
@@ -13,10 +13,10 @@ Import-Module $PathToManifest -Force
 Describe -Name $ModuleName -Fixture {
 
     $manifestContent = Test-ModuleManifest -Path $PathToManifest
+    $moduleExported = Get-Command -Module $ModuleName | Select-Object -ExpandProperty Name
 
     Context -Name 'Exported Commands' -Fixture {
         $manifestExported = ($manifestContent.ExportedFunctions).Keys
-        $moduleExported = Get-Command -Module $ModuleName | Select-Object -ExpandProperty Name
 
         Context -Name 'Number of commands' -Fixture {
             It -Name 'Exports the same number of public funtions as what is listed in the Module Manifest' -Test {
@@ -47,7 +47,7 @@ Describe -Name $ModuleName -Fixture {
                 }
 
                 It -Name 'Includes at least one example' -Test {
-                    $help.examples.Count | Should -BeGreaterOrEqual 1
+                    $help.examples.example.Count | Should -BeGreaterOrEqual 1
                 }
             }
         }


### PR DESCRIPTION
# Pull Request

## Description

Description of changes:

## [0.9.0]

- Catesta primary module changes
  - ExportedFunctions.Tests.ps1 - Corrected 2 bugs in Exported Commands test
    - Didn't correctly identify all commands
    - Didn't support example checks in PowerShell 5.1
  - Catesta manifest updates
    - Updated to use more recent versions of required modules
    - Sorted tags alphabetically
  - Catesta.build.ps1
    - Updated verbiage in ValidateRequirements to correctly reflect version of PowerShell required
    - Updated Add-BuildTask Test to output Pester test outputfile to testOutput location
    - Updated Add-BuildTask Test to correctly output Pester code coverage file
  - Updated tasks.json to reference ${workspaceFolder}
- Catesta template module changes
  - Build updates
    - Corrected 2 bugs in Exported Commands test
      - Didn't correctly identify all commands
      - Didn't support example checks in PowerShell 5.1
    - PSModule.build.ps1
      - Updated verbiage in ValidateRequirements to correctly reflect version of PowerShell required
      - Updated Add-BuildTask Test to output Pester test outputfile to testOutput location
      - Updated Add-BuildTask Test to correctly output Pester code coverage file
  - AWS Updates
    - Updated CFN deployments to use latest CodeBuild Images (2019)
      - windows-base:1.0 --> windows-base:2019-1.0
    - Updated buildspec_pwsh_windows.yml to download PowerShell 7.0.3 instead of 7.0.0
    - Updated module references to latest version
    - Added AWS.Tools.Common to install_modules.ps1
    - Added $PSVersionTable to pre_build commands of all yml files
    - Added support for Pester report groups in CodeBuild
    - Added support for Code Coverage reports groups in CodeBuild
  - Azure Updates
    - Added clarifying display names to each task
    - Added support for publishing test results
    - Added support for Code Coverage report
    - Updated actions_bootstrap.ps1 to install latest module versions
    - For windows powershell based build added line to remove Pester 5 and Import Pester 4.10.1 specifically.
    - Added support for attaching build artifact of Archived module build
  - GitHub Actions
    - Updated actions_bootstrap.ps1 to install latest module versions
    - Added name to all workflows for check out step
    - Changed checkout on all workflows from v1 to v2
    - Added pester test results artifact upload to all workflows
    - Renamed windows workflow that was using pwsh to ActionsTest-Windows-pwsh-Build
    - For windows powershell based build added line to remove Pester 5 and Import Pester 4.10.1 specifically.
  - Appveyor Updates
    - Updated actions_bootstrap.ps1 to install latest module versions
    - For windows powershell based build added line to remove Pester 5 and Import Pester 4.10.1 specifically.
    - Added support for all appveyor builds to include PesterTest, CodeCoverage, and build artifacts
- Editor updates
  - Added InvokeBuild tasks to tasks.json

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
