### PR TITLE
Use Line property instead of Matches and re-throw errors in GitHub actions

### DIFF
--- a/actions_bootstrap.ps1
+++ b/actions_bootstrap.ps1
@@ -53,6 +53,6 @@ foreach ($module in $modulesToInstall) {
     catch {
         $message = 'Failed to install {0}' -f $module.ModuleName
         "  - $message"
-        throw $message
+        throw
     }
 }

--- a/src/Catesta.build.ps1
+++ b/src/Catesta.build.ps1
@@ -327,7 +327,7 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
         Write-Build Yellow '             Please review the following sections in your comment based help, fill out missing information and rerun this build:'
         Write-Build Yellow '             (Note: This can happen if the .EXTERNALHELP CBH is defined for a function before running this build.)'
         Write-Build Yellow "             Path of files with issues: $($script:ArtifactsPath)\docs\"
-        $MissingDocumentation | Select-Object FileName, Matches | Format-Table -AutoSize
+        $MissingDocumentation | Select-Object FileName, Line | Format-Table -AutoSize
         throw 'Missing documentation. Please review and rebuild.'
     }
 


### PR DESCRIPTION
# Pull Request

## Issue

When Catesta detects missing comment-based help, it outputs the Matches property, shown below:

```powershell
Filename            Matches
--------            -------
Copy-LastCommand.md {0}
Copy-LastCommand.md {0}    
Copy-LastCommand.md {0}
Copy-LastCommand.md {0}
Edit-Profile.md     {0}
Edit-Profile.md     {0}
Edit-Profile.md     {0}
Edit-Profile.md     {0}
Get-Elevation.md    {0}    
Get-Elevation.md    {0}
Get-Elevation.md    {0}
Get-Elevation.md    {0}    
```

There's also a small issue I found when troubleshooting GitHub actions. The `Import-Module` error is not re-thrown, making it difficult to troubleshoot. Example:

```powershell
Installing PowerShell Modules
  - Successfully installed Pester
  - Successfully installed InvokeBuild
  - Successfully installed PSScriptAnalyzer
  - Successfully installed platyPS
  - Successfully installed posh-git
  - Successfully installed oh-my-posh
  - Failed to install Get-ChildItemColor
Failed to install Get-ChildItemColor
At D:\a\TsekProfile\TsekProfile\actions_bootstrap.ps1:70 char:5
+     throw $message
+     ~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Failed to install Get-ChildItemColor:String) [], RuntimeException
    + FullyQualifiedErrorId : Failed to install Get-ChildItemColor
```

## Description

It would be more useful to output the line that's missing documentation, as shown below:

```powershell
Filename            Line
--------            ----
Copy-LastCommand.md {{Fill in the Synopsis}}
Copy-LastCommand.md {{Fill in the Description}}
Copy-LastCommand.md PS C:\> {{ Add example code here }}
Copy-LastCommand.md {{ Add example description here }}
Edit-Profile.md     {{Fill in the Synopsis}}
Edit-Profile.md     {{Fill in the Description}}
Edit-Profile.md     PS C:\> {{ Add example code here }}
Edit-Profile.md     {{ Add example description here }} 
Get-Elevation.md    {{Fill in the Synopsis}}
Get-Elevation.md    {{Fill in the Description}}
Get-Elevation.md    PS C:\> {{ Add example code here }}
Get-Elevation.md    {{ Add example description here }}
```

Outputting the line property instead enables the user to quickly identify which documentation is missing.

With errors from `Import-Module` re-thrown, you'll see the following, as an example:

```powershell
Installing PowerShell Modules
  - Successfully installed Pester
  - Successfully installed InvokeBuild
  - Successfully installed PSScriptAnalyzer
  - Successfully installed platyPS
  - Successfully installed posh-git
  - Successfully installed oh-my-posh
  - Failed to install Get-ChildItemColor
PackageManagement\Install-Package : The following commands are already available on this system:'Out-Default'. This 
module 'Get-ChildItemColor' may override the existing commands. If you still want to install this module 
'Get-ChildItemColor', use -AllowClobber parameter.
At C:\Program Files\WindowsPowerShell\Modules\PowerShellGet\2.2.4.1\PSModule.psm1:9709 char:34
+ ... talledPackages = PackageManagement\Install-Package @PSBoundParameters
+                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (Microsoft.Power....InstallPackage:InstallPackage) [Install-Package],  
   Exception
    + FullyQualifiedErrorId : CommandAlreadyAvailable,Validate-ModuleCommandAlreadyAvailable,Microsoft.PowerShell.Pack 
   ageManagement.Cmdlets.InstallPackage
```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
