### PR TITLE
Fix function help example test

### DIFF
--- a/src/Tests/Unit/ExportedFunctions.Tests.ps1
+++ b/src/Tests/Unit/ExportedFunctions.Tests.ps1
@@ -46,8 +46,8 @@ Describe -Name $ModuleName -Fixture {
                     $help.description.Text | Should -Not -BeNullOrEmpty
                 }
 
-                It -Name 'Includes at least one example' -Test {
-                    $help.examples.example.Count | Should -BeGreaterOrEqual 1
+                It -Name 'Includes an Example' -Test {
+                    $help.examples.example | Should -Not -BeNullOrEmpty
                 }
             }
         }


### PR DESCRIPTION
# Pull Request

## Issue

Function help example tests fail initially, as `$help.examples.example` does not have the `count` member property.

Issue #, if available:

## Description

Description of changes:

Leverage the same tests used when testing function synopsis and description to ensure that the function help example exists, which is effectively the same as saying there's at least one example.

Tests run:

```powershell
$help = get-help Set-CustomPrompt -full

PS> $help.examples.example


-------------------------- EXAMPLE 1 --------------------------

PS C:\>Set-CustomPrompt -Symbol '26A1' -Force



Forces the prompt to change, using the 'High Voltage' Emoji (⚡) as the
ASCII character is placed before the cursor.

PS> $help.examples.example.count


PS> $help.examples.example | Get-Member 




   TypeName: MamlCommandHelpInfo#example

Name         MemberType   Definition
----         ----------   ----------
Equals       Method       bool Equals(System.Object obj)
GetHashCode  Method       int GetHashCode()
GetType      Method       type GetType()
ToString     Method       string ToString()
code         NoteProperty System.String code=Set-CustomPrompt -Symbol '26A1' -Force
introduction NoteProperty psobject[] introduction=System.Management.Automation.PSObject[]
remarks      NoteProperty psobject[] remarks=System.Management.Automation.PSObject[]
title        NoteProperty System.String title=-------------------------- EXAMPLE 1 --------------------------


```

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
