### PR TITLE
Remove Export-ModuleMember from Export

### DIFF
--- a/src/Catesta/Catesta.psm1
+++ b/src/Catesta/Catesta.psm1
@@ -29,6 +29,3 @@ foreach ($file in @($public + $private)) {
 
     }
 }
-
-# export all public functions
-Export-ModuleMember -Function $public.Basename


### PR DESCRIPTION
# Pull Request

## Issue

Issue #, if available: #37 

## Description

Description of changes:

Remove Export-ModuleMember from the module itself, and leave this to the manifest. Catesta executes Export-ModuleMember -Function $public.Basename as part of every time the module is imported ([link](https://github.com/techthoughts2/Catesta/blob/70f6c75ffad67fadbf4b841766fcadb381398dd4/src/Catesta/Catesta.psm1#L34)).

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
