### PR TITLE
GitHub based CloudFormation template still uses CodeBuild image version 4.0

### DIFF
--- a/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildGit.yml
+++ b/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildGit.yml
@@ -319,7 +319,7 @@ Resources:
       Environment:
         #ComputeType: !Ref CodeBuildComputeType
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: "aws/codebuild/standard:4.0"
+        Image: "aws/codebuild/standard:5.0"
         #Type: !Ref CodeBuildEnvironment
         Type: LINUX_CONTAINER
       Name: !Join


### PR DESCRIPTION
# Pull Request

## Issue

GitHub based CloudFormation template still uses CodeBuild image version 4.0. This was unexpected as the CodeCommit version of the CloudFormation template uses 5.0 and the Changelog entry mentions an upgrade to 5.0.

## Description

Description of changes:

Updated CloudFormation GitHub template to use CodeBuild image version 5.0.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
