### PR TITLE
Enhancements

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.5]
+
+- Catesta template module changes
+  - Fixed casing issue in all templates that caused Catesta to have an issue on certain Linux distros
+  - Fixed bug where vault templates were referencing an incorrect version of Microsoft.PowerShell.SecretManagement
+- Catesta primary module changes
+  - Added infrastructure tests to check for casing violations
+
 ## [1.2.3]
 
 - Minor spelling corrections throughout
@@ -41,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - ```buildspec_pwsh_windows.yml```
     - ```install_modules.ps1```
       - AWS.Tools.Common bumped from ```4.1.17.0``` to ```4.1.133```
-  - Minimum version of ```Microsoft.PowerShell.SecretManagement``` for vault builds is now ```1.2.3```
+  - Minimum version of ```Microsoft.PowerShell.SecretManagement``` for vault builds is now ```1.2.5```
 - Catesta primary module changes
   - ```tasks.json```
     - ```PesterTest```, ```Pester-Single-Coverage```, ```Pester-Single-Detailed```, ```DevCC-Single``` tasks no longer use legacy parameters for Pester 5
@@ -63,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - Updated reference links
     - ```install_modules.ps1```
       - Minor spelling correction
-      - AWS.Tools.Common bumped from ```4.1.2.3``` to ```4.1.17.0```
+      - AWS.Tools.Common bumped from ```4.1.2.5``` to ```4.1.17.0```
     - ```New-PowerShellProject.ps1``` & ```New-VaultProject.ps1```
       - Minor formatting updates
   - Appveyor CI/CD changes:

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Catesta primary module changes
   - InvokeBuild bumped from `5.9.11` to `5.9.12`
   - Build file: replaced use of `[PesterConfiguration]::new()` with `New-PesterConfiguration`
+  - Removed use of `Assert-MockCalled` from all tests
 
 ## [1.2.0]
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.5]
+## [1.2.6]
 
 - Catesta template module changes
   - Fixed casing issue in all templates that caused Catesta to have an issue on certain Linux distros
   - Fixed bug where vault templates were referencing an incorrect version of Microsoft.PowerShell.SecretManagement
+  - InvokeBuild bumped from `5.9.11` to `5.10.1`
+  - PSScriptAnalyzer bumped from `1.20.0` to `1.21.0`
 - Catesta primary module changes
   - Added infrastructure tests to check for casing violations
+  - InvokeBuild bumped from `5.9.11` to `5.10.1`
+  - PSScriptAnalyzer bumped from `1.20.0` to `1.21.0`
 
 ## [1.2.3]
 
@@ -49,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - ```buildspec_pwsh_windows.yml```
     - ```install_modules.ps1```
       - AWS.Tools.Common bumped from ```4.1.17.0``` to ```4.1.133```
-  - Minimum version of ```Microsoft.PowerShell.SecretManagement``` for vault builds is now ```1.2.5```
+  - Minimum version of ```Microsoft.PowerShell.SecretManagement``` for vault builds is now ```1.2.6```
 - Catesta primary module changes
   - ```tasks.json```
     - ```PesterTest```, ```Pester-Single-Coverage```, ```Pester-Single-Detailed```, ```DevCC-Single``` tasks no longer use legacy parameters for Pester 5
@@ -71,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - Updated reference links
     - ```install_modules.ps1```
       - Minor spelling correction
-      - AWS.Tools.Common bumped from ```4.1.2.5``` to ```4.1.17.0```
+      - AWS.Tools.Common bumped from ```4.1.2.6``` to ```4.1.17.0```
     - ```New-PowerShellProject.ps1``` & ```New-VaultProject.ps1```
       - Minor formatting updates
   - Appveyor CI/CD changes:

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,108 +32,108 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Catesta template module changes
   - Improved plaster references throughout Catesta to better handle situations when a user choose Pester 4 vs Pester 5. While this affects a few minor files it primarily focuses on updating the way VSCode tasks are engaged.
-    - ```tasks.json```
-      - ```PesterTest```, ```Pester-Single-Coverage```, ```Pester-Single-Detailed```, ```DevCC-Single``` tasks no longer use legacy parameters for Pester 5
-      - Updated to no longer reference the Module name directly. Instead ```${workspaceFolderBasename}``` is used throughout the tasks file now.
+    - `tasks.json`
+      - `PesterTest`, `Pester-Single-Coverage`, `Pester-Single-Detailed`, `DevCC-Single` tasks no longer use legacy parameters for Pester 5
+      - Updated to no longer reference the Module name directly. Instead `${workspaceFolderBasename}` is used throughout the tasks file now.
   - All bootstrap files:
-    - Pester bumped from ```5.3.1``` to ```5.3.3```
-    - InvokeBuild bumped from ```5.8.8``` to ```5.9.11```
-    - Microsoft.PowerShell.SecretManagement bumped from ```1.1.1``` to ```1.1.2```
+    - Pester bumped from `5.3.1` to `5.3.3`
+    - InvokeBuild bumped from `5.8.8` to `5.9.11`
+    - Microsoft.PowerShell.SecretManagement bumped from `1.1.1` to `1.1.2`
   - AWS CodeBuild CI/CD changes:
-    - ```PowerShellCodeBuildGit.yml```
-      - ```aws/codebuild/windows-base:2019-1.0``` to  ```aws/codebuild/windows-base:2019-2.0```
-      - ```aws/codebuild/standard:5.0``` to ```aws/codebuild/standard:6.0```
-      - All Lambdas updated from ```Runtime: python3.6``` to ```Runtime: python3.9```
-    - ```PowerShellCodeBuildGit.yml```
-      - ```aws/codebuild/windows-base:2019-1.0``` to  ```aws/codebuild/windows-base:2019-2.0```
-      - ```aws/codebuild/standard:5.0``` to ```aws/codebuild/standard:6.0```
+    - `PowerShellCodeBuildGit.yml`
+      - `aws/codebuild/windows-base:2019-1.0` to  `aws/codebuild/windows-base:2019-2.0`
+      - `aws/codebuild/standard:5.0` to `aws/codebuild/standard:6.0`
+      - All Lambdas updated from `Runtime: python3.6` to `Runtime: python3.9`
+    - `PowerShellCodeBuildGit.yml`
+      - `aws/codebuild/windows-base:2019-1.0` to  `aws/codebuild/windows-base:2019-2.0`
+      - `aws/codebuild/standard:5.0` to `aws/codebuild/standard:6.0`
     - buildspec updates
-      - Updated runtime version from ```dotnet: 3.1``` to ```dotnet: 6.0```
-        - ```buildspec_pwsh_linux.yml```
-        - ```buildspec_pwsh_windows.yml```
-    - ```install_modules.ps1```
-      - AWS.Tools.Common bumped from ```4.1.17.0``` to ```4.1.133```
-  - Minimum version of ```Microsoft.PowerShell.SecretManagement``` for vault builds is now ```1.2.6```
+      - Updated runtime version from `dotnet: 3.1` to `dotnet: 6.0`
+        - `buildspec_pwsh_linux.yml`
+        - `buildspec_pwsh_windows.yml`
+    - `install_modules.ps1`
+      - AWS.Tools.Common bumped from `4.1.17.0` to `4.1.133`
+  - Minimum version of `Microsoft.PowerShell.SecretManagement` for vault builds is now `1.2.6`
 - Catesta primary module changes
-  - ```tasks.json```
-    - ```PesterTest```, ```Pester-Single-Coverage```, ```Pester-Single-Detailed```, ```DevCC-Single``` tasks no longer use legacy parameters for Pester 5
-  - Pester bumped from ```5.3.1``` to ```5.3.3```
-  - InvokeBuild bumped from ```5.8.8``` to ```5.9.11```
+  - `tasks.json`
+    - `PesterTest`, `Pester-Single-Coverage`, `Pester-Single-Detailed`, `DevCC-Single` tasks no longer use legacy parameters for Pester 5
+  - Pester bumped from `5.3.1` to `5.3.3`
+  - InvokeBuild bumped from `5.8.8` to `5.9.11`
 
 ## [1.0.0]
 
 - Catesta template module changes
   - All build yaml files - added commented line for easily retrieving modules/variables/env variables are available in the build image
   - All bootstrap files:
-    - Pester bumped from ```5.2.2``` to ```5.3.1```
-    - InvokeBuild bumped from ```5.8.0``` to ```5.8.8```
-    - PSScriptAnalyzer bumped from ```1.19.1``` to ```1.20.0```
-    - Microsoft.PowerShell.SecretManagement bumped from ```1.0.0``` to ```1.1.1```
+    - Pester bumped from `5.2.2` to `5.3.1`
+    - InvokeBuild bumped from `5.8.0` to `5.8.8`
+    - PSScriptAnalyzer bumped from `1.19.1` to `1.20.0`
+    - Microsoft.PowerShell.SecretManagement bumped from `1.0.0` to `1.1.1`
   - AWS CodeBuild CI/CD changes:
-    - ```PowerShellCodeBuildGit.yml```
+    - `PowerShellCodeBuildGit.yml`
       - Now enables user to specify Branch name on Webhook filter. Default is set to main.
       - Updated reference links
-    - ```install_modules.ps1```
+    - `install_modules.ps1`
       - Minor spelling correction
-      - AWS.Tools.Common bumped from ```4.1.2.6``` to ```4.1.17.0```
-    - ```New-PowerShellProject.ps1``` & ```New-VaultProject.ps1```
+      - AWS.Tools.Common bumped from `4.1.2.6` to `4.1.17.0`
+    - `New-PowerShellProject.ps1` & `New-VaultProject.ps1`
       - Minor formatting updates
   - Appveyor CI/CD changes:
-    - ```appveyor.yml```
+    - `appveyor.yml`
       - Updated windows images to more recent versions
         - Windows Powershell from 2017 to 2019
         - PowerShell from 2019 to 2022
   - Azure DevOps CI/CD changes:
-    - ```azure-pipelines.yml```
+    - `azure-pipelines.yml`
       - ubuntu-latest
         - No longer installs PowerShell core (PowerShell 7 is now native to image)
-        - switched from script using ```pwsh -c ''``` style to native ```-pwsh: |``` call
+        - switched from script using `pwsh -c ''` style to native `-pwsh: |` call
       - macOS-latest
-        - switched from script using ```pwsh -c ''``` style to native ```-pwsh: |``` call
-  - ```tasks.json```
+        - switched from script using `pwsh -c ''` style to native `-pwsh: |` call
+  - `tasks.json`
     - Adjusted formatting
     - Updated documentation
     - Updated references to align with new tasks requirements
 - Catesta primary module changes
   - **Updated primary branch name from master to main**
     - Updated references from master to main throughout repository
-  - Pester bumped from ```5.2.2``` to ```5.3.3```
-  - InvokeBuild bumped from ```5.8.0``` to ```5.9.11```
-  - PSScriptAnalyzer bumped from ```1.19.1``` to ```1.20.0```
-  - ```tasks.json```
+  - Pester bumped from `5.2.2` to `5.3.3`
+  - InvokeBuild bumped from `5.8.0` to `5.9.11`
+  - PSScriptAnalyzer bumped from `1.19.1` to `1.20.0`
+  - `tasks.json`
     - Adjusted formatting
     - Updated documentation
     - Updated references to align with new tasks requirements
-  - ```Catesta.build.ps1```
+  - `Catesta.build.ps1`
     - Updated pester module import to use a min/max value
   - Documentation updates
     - Minor README corrections/updates
     - AWS
-      - Updated ```Catesta-AWS.md```
+      - Updated `Catesta-AWS.md`
       - Re-did several AWS diagrams and included raw drawio diagrams
       - Updated screenshots
     - AppVeyor
-      - Updated ```Catesta-AppVeyor.md```
+      - Updated `Catesta-AppVeyor.md`
       - Added diagram
       - Updated screenshots
     - GitHub Actions
-      - Updated ```Catesta-GHActions.md```
+      - Updated `Catesta-GHActions.md`
       - Added diagram
     - Azure DevOps
-      - Updated ```Catesta-Azure.md```
+      - Updated `Catesta-Azure.md`
       - Added diagram
-    - Updated ```Catesta-FAQ.md```
-    - Updated ```Catesta-Vault-Extension.md```
+    - Updated `Catesta-FAQ.md`
+    - Updated `Catesta-Vault-Extension.md`
 
 ## [0.12.4]
 
-- ```*.build.ps1```
-  - Test task now correctly references ```$script:UnitTestsPath``` instead of overall ```$script:TestsPath```
-  - DevCC task now correctly references ```$script:UnitTestsPath``` instead of ```'Tests\Unit'```
-  - Infra task now correctly references ```$script:InfraTestsPath``` instead of ```'Tests\Infrastructure'```
-  - Adjusted ValidateRequirements task to work with ```[version]``` type when verifying minimum version of PowerShell to validate
+- `*.build.ps1`
+  - Test task now correctly references `$script:UnitTestsPath` instead of overall `$script:TestsPath`
+  - DevCC task now correctly references `$script:UnitTestsPath` instead of `'Tests\Unit'`
+  - Infra task now correctly references `$script:InfraTestsPath` instead of `'Tests\Infrastructure'`
+  - Adjusted ValidateRequirements task to work with `[version]` type when verifying minimum version of PowerShell to validate
   - Added new BuildNoInfra task for building module without running Infra tests
-- ```tasks.json```
+- `tasks.json`
   - Added new VSCode tasks
     - BuildNoInfra - runs BuildNoInfra tasks
     - Pester-Single-Coverage - enables user to run pester test for single function and get code coverage report
@@ -142,7 +142,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.1]
 
-- Changed the Pester 5 minimum version requirement from ```v5.0.0``` to ```v5.2.2```
+- Changed the Pester 5 minimum version requirement from `v5.0.0` to `v5.2.2`
 - Updated CloudFormation GitHub template to use CodeBuild image version 5.0.
 
 ## [0.12.0]
@@ -152,7 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Some CICD containers have the Pester module loaded into memory. Added explicit remove in the build file to account for this.
     - Moved Pester import handling from the buildspec/yaml to InvokeBuild
   - Updated pester tests that were using legacy Should syntax (without dashes)
-  - Fixed ```tasks.json``` VSCode file to be valid json (was missing comma)
+  - Fixed `tasks.json` VSCode file to be valid json (was missing comma)
   - Added prompt on ModuleOnly module type to prompt user if they want helpful .vscode files for their module project
   - Catesta now deploys the initial sample module in a style that better reflects a real-world module
     - The private sample function was renamed to Get-Day and gets the day of the week
@@ -160,11 +160,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Sample tests are now created for these sample functions in the appropriate public/private folders under the Tests/Unit folder
     - Sample tests now actually test the sample functions
   - AppVeyor CI/CD changes:
-    - Updated Ubuntu image from ```Ubuntu1804``` to ```Ubuntu2004```
+    - Updated Ubuntu image from `Ubuntu1804` to `Ubuntu2004`
   - Azure DevOps CI/CD changes:
     - The latest macOS image [now includes PowerShell](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md) by default - removed step in yaml to install PowerShell.
   - AWS CodeBuild CI/CD changes:
-    - CB Linux Image updated in CFN from ```Image: aws/codebuild/standard:4.0``` to use latest: ```Image: aws/codebuild/standard:5.0```
+    - CB Linux Image updated in CFN from `Image: aws/codebuild/standard:4.0` to use latest: `Image: aws/codebuild/standard:5.0`
     - Updated buildspec_pwsh_windows.yml to use the new syntax for installing PowerShell 7.
 
       ```bash
@@ -173,11 +173,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       ```
 
     - Added additional documentation links to the buildspec files
-  - InvokeBuild bumped from ```5.6.1``` to ```5.8.0```
+  - InvokeBuild bumped from `5.6.1` to `5.8.0`
 - Catesta primary module changes
   - Updated pester tests that were using Legacy Should syntax (without dashes)
   - Updated pester tests to support v5+
-  - InvokeBuild bumped from ```5.6.1``` to ```5.8.0```
+  - InvokeBuild bumped from `5.6.1` to `5.8.0`
 
 ## [0.11.0]
 
@@ -185,8 +185,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New optional cmdlets
   - New metadata parameter on several cmdlets
 - Added new optional vault parent .psm1 example file
-- Catesta now references the GA version of ```Microsoft.PowerShell.SecretManagement```
-- Added best practice naming suggestion to ```New-VaultProject```
+- Catesta now references the GA version of `Microsoft.PowerShell.SecretManagement`
+- Added best practice naming suggestion to `New-VaultProject`
 - Corrected verbiage on several commands to properly reflect which module project was being scaffold
 - Fixed bug where module would fail to scaffold on Linux systems due to case sensitivity of path
 
@@ -232,7 +232,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Added build steps which import the module manifest explicitly
     - Adjusted ExportedFunctions.Tests.ps1 to check for included example rather than example count
 - Updated a few areas of documentation/help to provide more clarification
-- Updated .vscode settings to use ```${workspaceFolderBasename}``` instead of hard-coded Catesta name
+- Updated .vscode settings to use `${workspaceFolderBasename}` instead of hard-coded Catesta name
 
 ## [0.9.0]
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
         "Catesta",
         "CICD",
         "cmdlets",
+        "distros",
         "dotnet",
         "drawio",
         "Evalz",

--- a/actions_bootstrap.ps1
+++ b/actions_bootstrap.ps1
@@ -21,12 +21,12 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.9.11'
+            ModuleVersion = '5.10.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.20.0'
+            ModuleVersion = '1.21.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 1.2.3
+Help Version: 1.2.5
 Locale: en-US
 ---
 

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 1.2.5
+Help Version: 1.2.6
 Locale: en-US
 ---
 

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.2.5'
+    ModuleVersion     = '1.2.6'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.2.3'
+    ModuleVersion     = '1.2.5'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Resources/AWS/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/AWS/Vault/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>AWSCBVaultExtension</name>
     <id>58d9f168-a786-43e6-8b79-0766ded4fd22</id>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <title>Catesta - SecretManagement extension vault module template for AWS CodeBuild</title>
     <description>Scaffolds a new PowerShell SecretManagement extension vault module project intended for CI/CD workflow using AWS CodeBuild</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/AWS/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/AWS/Vault/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>AWSCBVaultExtension</name>
     <id>58d9f168-a786-43e6-8b79-0766ded4fd22</id>
-    <version>1.2.3</version>
+    <version>1.2.5</version>
     <title>Catesta - SecretManagement extension vault module template for AWS CodeBuild</title>
     <description>Scaffolds a new PowerShell SecretManagement extension vault module project intended for CI/CD workflow using AWS CodeBuild</description>
     <author>Jake Morrison</author>
@@ -116,7 +116,7 @@
     <requireModule condition="$PLASTER_PARAM_Pester -eq '5'" name="Pester" minimumVersion="5.2.2" message="Without Pester, you will not be able to run the provided Pester test to validate your module manifest file."/>
     <requireModule name="InvokeBuild" minimumVersion="5.8.0" message="Without InvokeBuild, you will not be able to run local builds."/>
     <requireModule name="platyPS" requiredVersion ="0.12.0" message="This template requires platyPS v0.12.0 module to properly generate help."/>
-    <requireModule name="Microsoft.PowerShell.SecretManagement" minimumVersion ="1.2.3" message="Without the PowerShell SecretManagement you will not be able to properly test your extension."/>
+    <requireModule name="Microsoft.PowerShell.SecretManagement" minimumVersion ="1.1.2" message="Without the PowerShell SecretManagement you will not be able to properly test your extension."/>
 
     <message>
 

--- a/src/Catesta/Resources/AWS/install_modules.ps1
+++ b/src/Catesta/Resources/AWS/install_modules.ps1
@@ -68,13 +68,13 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 %>
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.9.11'
+            ModuleVersion = '5.10.1'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.20.0'
+            ModuleVersion = '1.21.0'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))

--- a/src/Catesta/Resources/AWS/plasterManifest.xml
+++ b/src/Catesta/Resources/AWS/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>AWSCBManifestPS</name>
     <id>83670531-579c-4a4c-a70a-ddc60eaefa40</id>
-    <version>1.2.3</version>
+    <version>1.2.5</version>
     <title>Catesta - PowerShell Module Template for AWS CodeBuild</title>
     <description>Scaffolds a new PowerShell module project intended for CI/CD workflow using AWS CodeBuild</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/AWS/plasterManifest.xml
+++ b/src/Catesta/Resources/AWS/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>AWSCBManifestPS</name>
     <id>83670531-579c-4a4c-a70a-ddc60eaefa40</id>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <title>Catesta - PowerShell Module Template for AWS CodeBuild</title>
     <description>Scaffolds a new PowerShell module project intended for CI/CD workflow using AWS CodeBuild</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/AppVeyor/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/AppVeyor/Vault/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>AppVeyorVaultExtension</name>
     <id>0cb76f26-5b3b-4c6b-9396-91e2c6427b0f</id>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <title>Catesta - SecretManagement extension vault module template for AppVeyor</title>
     <description>Scaffolds a new PowerShell SecretManagement extension vault module project for CI/CD workflow using AppVeyor</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/AppVeyor/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/AppVeyor/Vault/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>AppVeyorVaultExtension</name>
     <id>0cb76f26-5b3b-4c6b-9396-91e2c6427b0f</id>
-    <version>1.2.3</version>
+    <version>1.2.5</version>
     <title>Catesta - SecretManagement extension vault module template for AppVeyor</title>
     <description>Scaffolds a new PowerShell SecretManagement extension vault module project for CI/CD workflow using AppVeyor</description>
     <author>Jake Morrison</author>
@@ -109,7 +109,7 @@
     <requireModule condition="$PLASTER_PARAM_Pester -eq '5'" name="Pester" minimumVersion="5.2.2" message="Without Pester, you will not be able to run the provided Pester test to validate your module manifest file."/>
     <requireModule name="InvokeBuild" minimumVersion="5.8.0" message="Without InvokeBuild, you will not be able to run local builds."/>
     <requireModule name="platyPS" requiredVersion ="0.12.0" message="This template requires platyPS v0.12.0 module to properly generate help."/>
-    <requireModule name="Microsoft.PowerShell.SecretManagement" minimumVersion ="1.2.3" message="Without the PowerShell SecretManagement you will not be able to properly test your extension."/>
+    <requireModule name="Microsoft.PowerShell.SecretManagement" minimumVersion ="1.1.2" message="Without the PowerShell SecretManagement you will not be able to properly test your extension."/>
 
     <message>
 

--- a/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
@@ -31,12 +31,12 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.9.11'
+            ModuleVersion = '5.10.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.20.0'
+            ModuleVersion = '1.21.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/src/Catesta/Resources/AppVeyor/plasterManifest.xml
+++ b/src/Catesta/Resources/AppVeyor/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>AppVeyorManifestPS</name>
     <id>e7c065d2-f8c5-4bf2-b33e-db50a62abbb4</id>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <title>Catesta - PSModule template for AppVeyor</title>
     <description>Scaffolds a new PowerShell module project intended for CI/CD workflow using AppVeyor</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/AppVeyor/plasterManifest.xml
+++ b/src/Catesta/Resources/AppVeyor/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>AppVeyorManifestPS</name>
     <id>e7c065d2-f8c5-4bf2-b33e-db50a62abbb4</id>
-    <version>1.2.3</version>
+    <version>1.2.5</version>
     <title>Catesta - PSModule template for AppVeyor</title>
     <description>Scaffolds a new PowerShell module project intended for CI/CD workflow using AppVeyor</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Azure/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Azure/Vault/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>AzureVaultExtension</name>
     <id>a2ccc3ba-a95f-4e17-9c95-8fa2f455e5bc</id>
-    <version>1.2.3</version>
+    <version>1.2.5</version>
     <title>Catesta - SecretManagement extension vault module template for Azure Pipelines</title>
     <description>Scaffolds a new PowerShell SecretManagement extension vault module project for CI/CD workflow using Azure Pipelines</description>
     <author>Jake Morrison</author>
@@ -109,7 +109,7 @@
     <requireModule condition="$PLASTER_PARAM_Pester -eq '5'" name="Pester" minimumVersion="5.2.2" message="Without Pester, you will not be able to run the provided Pester test to validate your module manifest file."/>
     <requireModule name="InvokeBuild" minimumVersion="5.8.0" message="Without InvokeBuild, you will not be able to run local builds."/>
     <requireModule name="platyPS" requiredVersion ="0.12.0" message="This template requires platyPS v0.12.0 module to properly generate help."/>
-    <requireModule name="Microsoft.PowerShell.SecretManagement" minimumVersion ="1.2.3" message="Without the PowerShell SecretManagement you will not be able to properly test your extension."/>
+    <requireModule name="Microsoft.PowerShell.SecretManagement" minimumVersion ="1.1.2" message="Without the PowerShell SecretManagement you will not be able to properly test your extension."/>
 
     <message>
 

--- a/src/Catesta/Resources/Azure/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Azure/Vault/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>AzureVaultExtension</name>
     <id>a2ccc3ba-a95f-4e17-9c95-8fa2f455e5bc</id>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <title>Catesta - SecretManagement extension vault module template for Azure Pipelines</title>
     <description>Scaffolds a new PowerShell SecretManagement extension vault module project for CI/CD workflow using Azure Pipelines</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Azure/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/Azure/actions_bootstrap.ps1
@@ -31,12 +31,12 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.9.11'
+            ModuleVersion = '5.10.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.20.0'
+            ModuleVersion = '1.21.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/src/Catesta/Resources/Azure/plasterManifest.xml
+++ b/src/Catesta/Resources/Azure/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>AzurePManifestPS</name>
     <id>74cef6b1-55b4-4247-9cc8-654d26cc1402</id>
-    <version>1.2.3</version>
+    <version>1.2.5</version>
     <title>Catesta - PowerShell Module Template for Azure Pipelines</title>
     <description>Scaffolds a new PowerShell module project intended for CI/CD workflow using Azure Pipelines</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Azure/plasterManifest.xml
+++ b/src/Catesta/Resources/Azure/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>AzurePManifestPS</name>
     <id>74cef6b1-55b4-4247-9cc8-654d26cc1402</id>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <title>Catesta - PowerShell Module Template for Azure Pipelines</title>
     <description>Scaffolds a new PowerShell module project intended for CI/CD workflow using Azure Pipelines</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/GitHubActions/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/GitHubActions/Vault/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>GHAVaultExtension</name>
     <id>02c6673d-bf8b-4997-b229-0d1856af4506</id>
-    <version>1.2.3</version>
+    <version>1.2.5</version>
     <title>Catesta - SecretManagement extension vault module template for GitHub Actions</title>
     <description>Scaffolds a new PowerShell SecretManagement extension vault module project for CI/CD workflow using GitHub Actions</description>
     <author>Jake Morrison</author>
@@ -112,7 +112,7 @@
     <requireModule condition="$PLASTER_PARAM_Pester -eq '5'" name="Pester" minimumVersion="5.2.2" message="Without Pester, you will not be able to run the provided Pester test to validate your module manifest file."/>
     <requireModule name="InvokeBuild" minimumVersion="5.8.0" message="Without InvokeBuild, you will not be able to run local builds."/>
     <requireModule name="platyPS" requiredVersion ="0.12.0" message="This template requires platyPS v0.12.0 module to properly generate help."/>
-    <requireModule name="Microsoft.PowerShell.SecretManagement" minimumVersion ="1.2.3" message="Without the PowerShell SecretManagement you will not be able to properly test your extension."/>
+    <requireModule name="Microsoft.PowerShell.SecretManagement" minimumVersion ="1.1.2" message="Without the PowerShell SecretManagement you will not be able to properly test your extension."/>
 
     <message>
 

--- a/src/Catesta/Resources/GitHubActions/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/GitHubActions/Vault/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>GHAVaultExtension</name>
     <id>02c6673d-bf8b-4997-b229-0d1856af4506</id>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <title>Catesta - SecretManagement extension vault module template for GitHub Actions</title>
     <description>Scaffolds a new PowerShell SecretManagement extension vault module project for CI/CD workflow using GitHub Actions</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
@@ -31,12 +31,12 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.9.11'
+            ModuleVersion = '5.10.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.20.0'
+            ModuleVersion = '1.21.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/src/Catesta/Resources/GitHubActions/plasterManifest.xml
+++ b/src/Catesta/Resources/GitHubActions/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>GHAManifestPS</name>
     <id>c336d3e8-c2b9-451d-a041-be4b84259ec9</id>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <title>Catesta - PowerShell Module Template for GitHub Actions</title>
     <description>Scaffolds a new PowerShell module project intended for CI/CD workflow using GitHub Actions</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/GitHubActions/plasterManifest.xml
+++ b/src/Catesta/Resources/GitHubActions/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>GHAManifestPS</name>
     <id>c336d3e8-c2b9-451d-a041-be4b84259ec9</id>
-    <version>1.2.3</version>
+    <version>1.2.5</version>
     <title>Catesta - PowerShell Module Template for GitHub Actions</title>
     <description>Scaffolds a new PowerShell module project intended for CI/CD workflow using GitHub Actions</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Vanilla/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Vanilla/Vault/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>BasicVaultExtension</name>
     <id>02346b16-467d-4936-be14-939dfdd94495</id>
-    <version>1.2.3</version>
+    <version>1.2.5</version>
     <title>Catesta - SecretManagement extension vault module template</title>
     <description>Scaffolds a new PowerShell SecretManagement extension vault module project</description>
     <author>Jake Morrison</author>
@@ -100,7 +100,7 @@
     <requireModule condition="$PLASTER_PARAM_Pester -eq '5'" name="Pester" minimumVersion="5.2.2" message="Without Pester, you will not be able to run the provided Pester test to validate your module manifest file."/>
     <requireModule name="InvokeBuild" minimumVersion="5.8.0" message="Without InvokeBuild, you will not be able to run local builds."/>
     <requireModule name="platyPS" requiredVersion ="0.12.0" message="This template requires platyPS v0.12.0 module to properly generate help."/>
-    <requireModule name="Microsoft.PowerShell.SecretManagement" minimumVersion ="1.2.3" message="Without the PowerShell SecretManagement you will not be able to properly test your extension."/>
+    <requireModule name="Microsoft.PowerShell.SecretManagement" minimumVersion ="1.1.2" message="Without the PowerShell SecretManagement you will not be able to properly test your extension."/>
 
     <message>
 

--- a/src/Catesta/Resources/Vanilla/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Vanilla/Vault/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>BasicVaultExtension</name>
     <id>02346b16-467d-4936-be14-939dfdd94495</id>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <title>Catesta - SecretManagement extension vault module template</title>
     <description>Scaffolds a new PowerShell SecretManagement extension vault module project</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Vanilla/plasterManifest.xml
+++ b/src/Catesta/Resources/Vanilla/plasterManifest.xml
@@ -4,7 +4,7 @@
   <metadata>
     <name>BasicManifestPS</name>
     <id>c95c4daa-7715-4429-839e-158412655abb</id>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <title>Catesta - Basic PSModule template</title>
     <description>Scaffolds a new PowerShell module project</description>
     <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Vanilla/plasterManifest.xml
+++ b/src/Catesta/Resources/Vanilla/plasterManifest.xml
@@ -4,11 +4,11 @@
   <metadata>
     <name>BasicManifestPS</name>
     <id>c95c4daa-7715-4429-839e-158412655abb</id>
-    <version>1.2.3</version>
+    <version>1.2.5</version>
     <title>Catesta - Basic PSModule template</title>
     <description>Scaffolds a new PowerShell module project</description>
     <author>Jake Morrison</author>
-    <tags>PowerShell,Template,PowerShell Module</tags>
+    <tags>PowerShell,Template,PowerShell Module, public</tags>
   </metadata>
   <parameters>
     <parameter name='VAULT' type='text' prompt='NOTVAULT'/>

--- a/src/Tests/Unit/Public/New-VaultProject.Tests.ps1
+++ b/src/Tests/Unit/Public/New-VaultProject.Tests.ps1
@@ -26,7 +26,6 @@ InModuleScope $ModuleName {
                 Mock New-VaultProject {}
             }
             It 'Should process by default' {
-
                 New-VaultProject -CICDChoice 'AWS' -DestinationPath c:\path
                 Should -Invoke -CommandName New-VaultProject -Exactly -Times 1 -Scope It
             } #it


### PR DESCRIPTION
# Pull Request

## Issue

Fixes #59

## Description

- Catesta template module changes
  - Fixed casing issue in all templates that caused Catesta to have an issue on certain Linux distros
  - Fixed bug where vault templates were referencing an incorrect version of Microsoft.PowerShell.SecretManagement
  - InvokeBuild bumped from `5.9.11` to `5.10.1`
  - PSScriptAnalyzer bumped from `1.20.0` to `1.21.0`
- Catesta primary module changes
  - Added infrastructure tests to check for casing violations
  - InvokeBuild bumped from `5.9.11` to `5.10.1`
  - PSScriptAnalyzer bumped from `1.20.0` to `1.21.0`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
