### PR TITLE
Enhancements

### DIFF
--- a/actions_bootstrap.ps1
+++ b/actions_bootstrap.ps1
@@ -7,30 +7,30 @@ Get-PackageProvider -Name Nuget -ForceBootstrap | Out-Null
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 
 # List of PowerShell Modules required for the build
-$modulesToInstall = [System.Collections.ArrayList]::new()
+$modulesToInstall = New-Object System.Collections.Generic.List[object]
 # https://github.com/PowerShell/Plaster
-$null = $modulesToInstall.Add(([PSCustomObject]@{
-    ModuleName    = 'Plaster'
-    ModuleVersion = '1.1.4'
-}))
+[void]$modulesToInstall.Add(([PSCustomObject]@{
+            ModuleName    = 'Plaster'
+            ModuleVersion = '1.1.4'
+        }))
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '5.5.0'
         }))
 # https://github.com/nightroman/Invoke-Build
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
             ModuleVersion = '5.10.5'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
             ModuleVersion = '1.21.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'platyPS'
             ModuleVersion = '0.12.0'
         }))

--- a/actions_bootstrap.ps1
+++ b/actions_bootstrap.ps1
@@ -21,7 +21,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.4'
+            ModuleVersion = '5.10.5'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/actions_bootstrap.ps1
+++ b/actions_bootstrap.ps1
@@ -11,17 +11,17 @@ $modulesToInstall = [System.Collections.ArrayList]::new()
 # https://github.com/PowerShell/Plaster
 $null = $modulesToInstall.Add(([PSCustomObject]@{
     ModuleName    = 'Plaster'
-    ModuleVersion = '1.1.3'
+    ModuleVersion = '1.1.4'
 }))
 # https://github.com/pester/Pester
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.4.0'
+            ModuleVersion = '5.5.0'
         }))
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.2'
+            ModuleVersion = '5.10.4'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Catesta template module changes
     - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script. This is to account for an issue in PowerShell `7.4.0`+ where a new parameter was introduced that platyPS can not handle during help creation. Ref: [platyPS issue]([text](https://github.com/PowerShell/platyPS/issues/595)).
         - If a build is run and the build environment is `7.4.0`+ the Markdown repair will run to account for the new parameter and repair markdown for help creation.
+    - Replaced uses of `System.Collections.ArrayList` with `System.Collections.Generic.List` throughout.
     - CI/CD Changes:
         - Azure:
             - Updated `testRunner` alias reference to `testResultsFormat`
@@ -21,11 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - Plaster bumped from `1.1.3` to `1.1.4`
         - Pester bumped from `5.4.0` to `5.5.0`
         - InvokeBuild bumped from `5.10.2` to `5.10.5`
-
 - Catesta primary module changes
     - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script.
     - Updated `LicenseUri` and `IconUri` link in `psd1` manifest.
     - Updated link references in inline help for both public functions
+    - Replaced uses of `System.Collections.ArrayList` with `System.Collections.Generic.List` throughout.
     - Plaster bumped from `1.1.3` to `1.1.4`
     - Pester bumped from `5.4.0` to `5.5.0`
     - InvokeBuild bumped from `5.10.2` to `5.10.5`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,9 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - CI/CD Changes:
         - Azure:
             - Updated `testRunner` alias reference to `testResultsFormat`
+        - AWS CodeBuild CI/CD changes:
+            - `PowerShellCodeBuildCC.yml`
+                - `aws/codebuild/standard:6.0` to `aws/codebuild/standard:7.0`
+            - `PowerShellCodeBuildGit.yml`
+                - `aws/codebuild/standard:6.0` to `aws/codebuild/standard:7.0`
         - Plaster bumped from `1.1.3` to `1.1.4`
         - Pester bumped from `5.4.0` to `5.5.0`
         - InvokeBuild bumped from `5.10.2` to `5.10.5`
+
 - Catesta primary module changes
     - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script.
     - Updated `LicenseUri` and `IconUri` link in `psd1` manifest.
@@ -125,7 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - InvokeBuild bumped from `5.8.8` to `5.9.11`
         - Microsoft.PowerShell.SecretManagement bumped from `1.1.1` to `1.1.2`
     - AWS CodeBuild CI/CD changes:
-        - `PowerShellCodeBuildGit.yml`
+        - `PowerShellCodeBuildCC.yml`
             - `aws/codebuild/windows-base:2019-1.0` to  `aws/codebuild/windows-base:2019-2.0`
             - `aws/codebuild/standard:5.0` to `aws/codebuild/standard:6.0`
             - All Lambdas updated from `Runtime: python3.6` to `Runtime: python3.9`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Catesta primary module changes
     - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script.
     - Updated `LicenseUri` and `IconUri` link in `psd1` manifest.
+    - Updated link references in inline help for both public functions
     - Plaster bumped from `1.1.3` to `1.1.4`
     - Pester bumped from `5.4.0` to `5.5.0`
     - InvokeBuild bumped from `5.10.2` to `5.10.5`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.2]
+## [2.2.0]
 
 - Catesta template module changes
+    - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script. This is to account for an issue in PowerShell `7.4.0`+ where a new parameter was introduced that platyPS can not handle during help creation. Ref: [platyPS issue]([text](https://github.com/PowerShell/platyPS/issues/595)).
+        - If a build is run and the build environment is `7.4.0`+ the Markdown repair will run to account for the new parameter and repair markdown for help creation.
     - CI/CD Changes:
         - Azure:
             - Updated `testRunner` alias reference to `testResultsFormat`
@@ -15,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - Pester bumped from `5.4.0` to `5.5.0`
         - InvokeBuild bumped from `5.10.2` to `5.10.4`
 - Catesta primary module changes
+    - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script.
     - Plaster bumped from `1.1.3` to `1.1.4`
     - Pester bumped from `5.4.0` to `5.5.0`
     - InvokeBuild bumped from `5.10.2` to `5.10.4`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2]
+
+- Catesta template module changes
+    - CI/CD Changes:
+        - Azure:
+            - Updated `testRunner` alias reference to `testResultsFormat`
+        - Plaster bumped from `1.1.3` to `1.1.4`
+        - Pester bumped from `5.4.0` to `5.5.0`
+        - InvokeBuild bumped from `5.10.2` to `5.10.4`
+- Catesta primary module changes
+    - Plaster bumped from `1.1.3` to `1.1.4`
+    - Pester bumped from `5.4.0` to `5.5.0`
+    - InvokeBuild bumped from `5.10.2` to `5.10.4`
+
 ## [2.0.0] - *breaking changes introduced*
 
 - Catesta template module changes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - InvokeBuild bumped from `5.10.2` to `5.10.5`
 - Catesta primary module changes
     - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script.
+    - Updated `LicenseUri` and `IconUri` link in `psd1` manifest.
     - Plaster bumped from `1.1.3` to `1.1.4`
     - Pester bumped from `5.4.0` to `5.5.0`
     - InvokeBuild bumped from `5.10.2` to `5.10.5`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,12 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
             - Updated `testRunner` alias reference to `testResultsFormat`
         - Plaster bumped from `1.1.3` to `1.1.4`
         - Pester bumped from `5.4.0` to `5.5.0`
-        - InvokeBuild bumped from `5.10.2` to `5.10.4`
+        - InvokeBuild bumped from `5.10.2` to `5.10.5`
 - Catesta primary module changes
     - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script.
     - Plaster bumped from `1.1.3` to `1.1.4`
     - Pester bumped from `5.4.0` to `5.5.0`
-    - InvokeBuild bumped from `5.10.2` to `5.10.4`
+    - InvokeBuild bumped from `5.10.2` to `5.10.5`
 
 ## [2.0.0] - *breaking changes introduced*
 

--- a/docs/Catesta-FAQ.md
+++ b/docs/Catesta-FAQ.md
@@ -121,6 +121,22 @@ By default a freshly created vault extension module already violates several PSS
 
 This is normal, and the build / test validation process is doing it's job. You'll need to correct your manifest to not use wildcards. You will also need to add content to your extension psm1 to actually engage the variables.
 
+## ProgressAction Error During Build Issue When Creating Help
+
+### Issue Overview
+
+In Catesta versions prior to `v2.2.0`, you might encounter an issue during the `CreateMarkDownHelp` step if you're running PowerShell `7.4.0` or higher. This is due to a new parameter, `ProgressAction`, [introduced in PowerShell 7.4.0(https://learn.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-powershell-74?view=powershell-7.4), which platyPS cannot handle during help creation. The error typically displays missing sections in the generated Markdown, prompting you to fill out information in your comment-based help.
+
+platyPS GitHub Issue: [PlatyPS needs to support the new ProgressAction common parameter #595](https://github.com/PowerShell/platyPS/issues/595)
+
+### Resolution
+
+This issue has been addressed in [Catesta v2.2.0](https://github.com/techthoughts2/Catesta/issues/71). To resolve the error, upgrade your Catesta to version `v2.2.0` or later. The fix includes the addition of `MarkdownRepair.ps1` and an update to the `InvokeBuild` script to include markdown repair logic. This repair step accounts for the new parameter and corrects the markdown for help creation.
+
+#### For Existing Projects
+
+If you have an existing module built with an older version of Catesta and are experiencing this issue, you can manually apply the fix. You can either create a new module with Catesta `v2.2.0` or later and copy the generated `MarkdownRepair.ps1` and updated `InvokeBuild` logic, or directly incorporate these changes from the Catesta GitHub repository.
+
 ## Why is it called Catesta
 
 It's a unique and meaningful name, combining two Latin words - "catasta" meaning scaffold, and "testa" meaning shell. This combination perfectly represents the purpose of Catesta, which is to provide a scaffold for PowerShell projects.

--- a/docs/Catesta-FAQ.md
+++ b/docs/Catesta-FAQ.md
@@ -11,11 +11,11 @@ Badge examples:
     ![AWS CodeBuild Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiL2FvTzZsNGFoL1VTTk1UOGE3WXlwSVFRT3BTWngzc1czdVZLTEpNYWJld2xSbS9Ea3R0b3ZETm96Zk5md2ZXMVUwNXZnSnlaRlpuWUJldzdGMENpemRjPSIsIml2UGFyYW1ldGVyU3BlYyI6Ikl3T3VwdU43UUxya0J1SVciLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
     ```
 
-- **GitHub Actions**: [![GitHub Actions Build Status Windows pwsh Master](https://github.com/techthoughts2/Catesta/workflows/Catesta-Windows-pwsh/badge.svg?branch=master)](https://github.com/techthoughts2/Catesta/actions)
+- **GitHub Actions**: [![GitHub Actions Build Status Windows pwsh Main](https://github.com/techthoughts2/Catesta/workflows/Catesta-Windows-pwsh/badge.svg?branch=main)](https://github.com/techthoughts2/Catesta/actions)
     - *Just replace the link with your repo*
 
     ```plain
-    [![GitHub Actions Build Status Windows pwsh Master](https://github.com/techthoughts2/Catesta/workflows/Catesta-Windows-pwsh/badge.svg?branch=master)](https://github.com/techthoughts2/Catesta/actions)
+    [![GitHub Actions Build Status Windows pwsh Main](https://github.com/techthoughts2/Catesta/workflows/Catesta-Windows-pwsh/badge.svg?branch=main)](https://github.com/techthoughts2/Catesta/actions)
     ```
 
 - **Appveyor**: [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/kech4dkqsrb9xuet/branch/master?svg=true)](https://ci.appveyor.com/project/techthoughts2/appveyortest/branch/master)

--- a/docs/Catesta-ModuleSchema.md
+++ b/docs/Catesta-ModuleSchema.md
@@ -260,7 +260,6 @@ Help            = 'Yes'
 Pester          = '5'
 
 
-
 }
 New-ModuleProject -ModuleParameters $moduleParameters -DestinationPath .
 ```

--- a/docs/Catesta-VaultSchema.md
+++ b/docs/Catesta-VaultSchema.md
@@ -251,7 +251,6 @@ CodingStyle     = 'Stroustrup'
 Pester          = '5'
 
 
-
 }
 New-ModuleProject -ModuleParameters $vaultParameters -DestinationPath .
 ```

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 2.0.0
+Help Version: 2.0.2
 Locale: en-US
 ---
 

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 2.0.2
+Help Version: 2.2.0
 Locale: en-US
 ---
 

--- a/docs/New-ModuleProject.md
+++ b/docs/New-ModuleProject.md
@@ -357,7 +357,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -Verbose, -WarningAction, -WarningVariable, and -ProgressAction. 
 For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -382,4 +382,3 @@ Read the manifest schemas to understand how to properly craft a ModuleParameters
 [https://www.catesta.dev/en/latest/New-ModuleProject/](https://www.catesta.dev/en/latest/New-ModuleProject/)
 
 [https://docs.microsoft.com/powershell/scripting/developer/module/writing-a-windows-powershell-module](https://docs.microsoft.com/powershell/scripting/developer/module/writing-a-windows-powershell-module)
-

--- a/docs/New-ModuleProject.md
+++ b/docs/New-ModuleProject.md
@@ -1,7 +1,7 @@
 ---
 external help file: Catesta-help.xml
 Module Name: Catesta
-online version: https://www.catesta.dev
+online version: https://www.catesta.dev/en/latest/New-ModuleProject/
 schema: 2.0.0
 ---
 
@@ -376,8 +376,6 @@ in ModuleParameters that are not supported.
 Read the manifest schemas to understand how to properly craft a ModuleParameters table.
 
 ## RELATED LINKS
-
-[https://www.catesta.dev](https://www.catesta.dev)
 
 [https://www.catesta.dev/en/latest/New-ModuleProject/](https://www.catesta.dev/en/latest/New-ModuleProject/)
 

--- a/docs/New-VaultProject.md
+++ b/docs/New-VaultProject.md
@@ -1,7 +1,7 @@
 ---
 external help file: Catesta-help.xml
 Module Name: Catesta
-online version: https://www.catesta.dev
+online version: https://www.catesta.dev/en/latest/New-VaultProject/
 schema: 2.0.0
 ---
 
@@ -361,8 +361,6 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 Author: Jake Morrison - @jakemorrison - https://www.techthoughts.info/
 
 ## RELATED LINKS
-
-[https://www.catesta.dev](https://www.catesta.dev)
 
 [https://www.catesta.dev/en/latest/New-VaultProject/](https://www.catesta.dev/en/latest/New-VaultProject/)
 

--- a/docs/New-VaultProject.md
+++ b/docs/New-VaultProject.md
@@ -349,7 +349,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -Verbose, -WarningAction, -WarningVariable, and -ProgressAction. 
 For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -369,4 +369,3 @@ Author: Jake Morrison - @jakemorrison - https://www.techthoughts.info/
 [https://www.catesta.dev/en/latest/Catesta-Vault-Extension/](https://www.catesta.dev/en/latest/Catesta-Vault-Extension/)
 
 [https://github.com/PowerShell/SecretManagement](https://github.com/PowerShell/SecretManagement)
-

--- a/src/Catesta.build.ps1
+++ b/src/Catesta.build.ps1
@@ -396,6 +396,17 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
         throw 'Missing GUID. Please review and rebuild.'
     }
 
+    Write-Build Gray '           Evaluating if running 7.4.0 or higher...'
+    # https://github.com/PowerShell/platyPS/issues/595
+    if ($PSVersionTable.PSVersion -ge [version]'7.4.0') {
+        Write-Build Gray '               Performing Markdown repair'
+        # dot source markdown repair
+        . $BuildRoot\MarkdownRepair.ps1
+        $OutputDir | Get-ChildItem -File | ForEach-Object {
+            Repair-PlatyPSMarkdown -Path $_.FullName
+        }
+    }
+
     Write-Build Gray '           Checking for missing documentation in md files...'
     $MissingDocumentation = Select-String -Path "$script:ArtifactsPath\docs\*.md" -Pattern "({{.*}})"
     if ($MissingDocumentation.Count -gt 0) {

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.0.2'
+    ModuleVersion     = '2.2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -166,13 +166,13 @@
             )
 
             # A URL to the license for this module.
-            # LicenseUri = 'https://github.com/techthoughts2/Catesta/blob/main/LICENSE'
+            LicenseUri               = 'https://github.com/techthoughts2/Catesta/blob/main/LICENSE'
 
             # A URL to the main website for this project.
             ProjectUri               = 'https://github.com/techthoughts2/Catesta'
 
             # A URL to an icon representing this module.
-            IconUri                  = 'https://github.com/techthoughts2/Catesta/raw/main/media/CatestaIcon.png'
+            IconUri                  = 'https://github.com/techthoughts2/Catesta/raw/main/docs/assets/CatestaIcon.png'
 
             # ReleaseNotes of this module
             ReleaseNotes             = 'https://github.com/techthoughts2/Catesta/blob/main/docs/CHANGELOG.md'

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.0.0'
+    ModuleVersion     = '2.0.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -54,7 +54,7 @@
     RequiredModules   = @(
         @{
             ModuleName    = 'Plaster'
-            ModuleVersion = '1.1.3'
+            ModuleVersion = '1.1.4'
         },
         @{
             ModuleName    = 'Pester'
@@ -190,7 +190,7 @@
             Extensions               = @(
                 @{
                     Module         = 'Plaster'
-                    MinimumVersion = '1.1.3'
+                    MinimumVersion = '1.1.4'
                     Details        = @{
                         TemplatePaths = @(
                             'Resources\Module',

--- a/src/Catesta/Public/New-ModuleProject.ps1
+++ b/src/Catesta/Public/New-ModuleProject.ps1
@@ -203,8 +203,6 @@
     Due to the nature of the lower level Plaster engagement, this means it is possible to pass hashtable choices
     in ModuleParameters that are not supported. Read the manifest schemas to understand how to properly craft a ModuleParameters table.
 .LINK
-    https://www.catesta.dev
-.LINK
     https://www.catesta.dev/en/latest/New-ModuleProject/
 .LINK
     https://docs.microsoft.com/powershell/scripting/developer/module/writing-a-windows-powershell-module

--- a/src/Catesta/Public/New-VaultProject.ps1
+++ b/src/Catesta/Public/New-VaultProject.ps1
@@ -190,8 +190,6 @@
 .NOTES
     Author: Jake Morrison - @jakemorrison - https://www.techthoughts.info/
 .LINK
-    https://www.catesta.dev
-.LINK
     https://www.catesta.dev/en/latest/New-VaultProject/
 .LINK
     https://www.catesta.dev/en/latest/Catesta-Vault-Extension/

--- a/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildCC.yml
+++ b/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildCC.yml
@@ -496,7 +496,7 @@ Resources:
       Description: !Ref CodeCommitRepositoryDescription
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:6.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: main_bucket

--- a/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildGit.yml
+++ b/src/Catesta/Resources/AWS/CloudFormation/PowerShellCodeBuildGit.yml
@@ -364,7 +364,7 @@ Resources:
       Environment:
         #ComputeType: !Ref CodeBuildComputeType
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:6.0
+        Image: aws/codebuild/standard:7.0
         #Type: !Ref CodeBuildEnvironment
         Type: LINUX_CONTAINER
       Name: !Join

--- a/src/Catesta/Resources/AWS/install_modules.ps1
+++ b/src/Catesta/Resources/AWS/install_modules.ps1
@@ -68,7 +68,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 %>
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.4'
+            ModuleVersion = '5.10.5'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))

--- a/src/Catesta/Resources/AWS/install_modules.ps1
+++ b/src/Catesta/Resources/AWS/install_modules.ps1
@@ -59,7 +59,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 $null = $modulesToInstall.Add(([PSCustomObject]@{
     ModuleName    = 'Pester'
-    ModuleVersion = '5.4.0'
+    ModuleVersion = '5.5.0'
     BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
     KeyPrefix     = ''
 }))
@@ -68,7 +68,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 %>
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.2'
+            ModuleVersion = '5.10.4'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))

--- a/src/Catesta/Resources/AWS/install_modules.ps1
+++ b/src/Catesta/Resources/AWS/install_modules.ps1
@@ -41,12 +41,12 @@ $VerbosePreference = 'SilentlyContinue'
 
 # List of PowerShell Modules required for the build
 # The AWS PowerShell Modules are added below, based on the $PSEdition
-$modulesToInstall = [System.Collections.ArrayList]::new()
+$modulesToInstall = New-Object System.Collections.Generic.List[object]
 <%
 if ($PLASTER_PARAM_Pester-eq '4') {
 @'
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
     ModuleName    = 'Pester'
     ModuleVersion = '4.10.1'
     BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
@@ -57,7 +57,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 elseif ($PLASTER_PARAM_Pester-eq '5') {
 @'
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
     ModuleName    = 'Pester'
     ModuleVersion = '5.5.0'
     BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
@@ -66,25 +66,25 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 '@
 }
 %>
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
             ModuleVersion = '5.10.5'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
             ModuleVersion = '1.21.0'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'platyPS'
             ModuleVersion = '0.12.0'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'AWS.Tools.Common'
             ModuleVersion = '4.1.133'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
@@ -94,7 +94,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 <%
 if ($PLASTER_PARAM_VAULT -eq 'VAULT') {
     @'
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Microsoft.PowerShell.SecretManagement'
             ModuleVersion = '1.1.2'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
@@ -113,7 +113,7 @@ if ($galleryDownload -eq $false) {
         if ($PSEdition -eq 'Core') {
             $moduleInstallPath = [System.IO.Path]::Combine($env:ProgramFiles, 'PowerShell', 'Modules')
             # Add the AWSPowerShell.NetCore Module
-            # $null = $modulesToInstall.Add(([PSCustomObject]@{
+            # [void]$modulesToInstall.Add(([PSCustomObject]@{
             #     ModuleName    = 'AWSPowerShell.NetCore'
             #     ModuleVersion = '3.3.604.0'
             #     BucketName    = 'ps-invoke-modules'
@@ -123,7 +123,7 @@ if ($galleryDownload -eq $false) {
         else {
             $moduleInstallPath = [System.IO.Path]::Combine($env:ProgramFiles, 'WindowsPowerShell', 'Modules')
             # Add the AWSPowerShell Module
-            # $null = $modulesToInstall.Add(([PSCustomObject]@{
+            # [void]$modulesToInstall.Add(([PSCustomObject]@{
             #     ModuleName    = 'AWSPowerShell'
             #     ModuleVersion = '3.3.604.0'
             #     BucketName    = 'ps-invoke-modules'
@@ -135,7 +135,7 @@ if ($galleryDownload -eq $false) {
         $moduleInstallPath = [System.IO.Path]::Combine('/', 'usr', 'local', 'share', 'powershell', 'Modules')
 
         # Add the AWSPowerShell.NetCore Module
-        # $null = $modulesToInstall.Add(([PSCustomObject]@{
+        # [void]$modulesToInstall.Add(([PSCustomObject]@{
         #     ModuleName    = 'AWSPowerShell.NetCore'
         #     ModuleVersion = '3.3.604.0'
         #     BucketName    = 'ps-invoke-modules'
@@ -145,7 +145,7 @@ if ($galleryDownload -eq $false) {
     elseif ($PSEdition -eq 'Desktop') {
         $moduleInstallPath = [System.IO.Path]::Combine($env:ProgramFiles, 'WindowsPowerShell', 'Modules')
         # Add the AWSPowerShell Module
-        # $null = $modulesToInstall.Add(([PSCustomObject]@{
+        # [void]$modulesToInstall.Add(([PSCustomObject]@{
         #     ModuleName    = 'AWSPowerShell'
         #     ModuleVersion = '3.3.604.0'
         #     BucketName    = 'ps-invoke-modules'

--- a/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
@@ -7,12 +7,12 @@ Get-PackageProvider -Name Nuget -ForceBootstrap | Out-Null
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 
 # List of PowerShell Modules required for the build
-$modulesToInstall = [System.Collections.ArrayList]::new()
+$modulesToInstall = New-Object System.Collections.Generic.List[object]
 <%
 if ($PLASTER_PARAM_Pester-eq '4') {
 @'
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '4.10.1'
         }))
@@ -21,7 +21,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 elseif ($PLASTER_PARAM_Pester-eq '5') {
 @'
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '5.5.0'
         }))
@@ -29,18 +29,18 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 }
 %>
 # https://github.com/nightroman/Invoke-Build
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
             ModuleVersion = '5.10.5'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
             ModuleVersion = '1.21.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'platyPS'
             ModuleVersion = '0.12.0'
         }))
@@ -48,7 +48,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 <%
 if ($PLASTER_PARAM_VAULT -eq 'VAULT') {
     @'
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Microsoft.PowerShell.SecretManagement'
             ModuleVersion = '1.1.2'
         }))

--- a/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
@@ -31,7 +31,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.4'
+            ModuleVersion = '5.10.5'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
@@ -23,7 +23,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.4.0'
+            ModuleVersion = '5.5.0'
         }))
 '@
 }
@@ -31,7 +31,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.2'
+            ModuleVersion = '5.10.4'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/src/Catesta/Resources/Azure/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/Azure/actions_bootstrap.ps1
@@ -7,12 +7,12 @@ Get-PackageProvider -Name Nuget -ForceBootstrap | Out-Null
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 
 # List of PowerShell Modules required for the build
-$modulesToInstall = [System.Collections.ArrayList]::new()
+$modulesToInstall = New-Object System.Collections.Generic.List[object]
 <%
 if ($PLASTER_PARAM_Pester-eq '4') {
 @'
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '4.10.1'
         }))
@@ -21,7 +21,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 elseif ($PLASTER_PARAM_Pester-eq '5') {
 @'
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '5.5.0'
         }))
@@ -29,18 +29,18 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 }
 %>
 # https://github.com/nightroman/Invoke-Build
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
             ModuleVersion = '5.10.5'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
             ModuleVersion = '1.21.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'platyPS'
             ModuleVersion = '0.12.0'
         }))
@@ -48,7 +48,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 <%
 if ($PLASTER_PARAM_VAULT -eq 'VAULT') {
     @'
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Microsoft.PowerShell.SecretManagement'
             ModuleVersion = '1.1.2'
         }))

--- a/src/Catesta/Resources/Azure/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/Azure/actions_bootstrap.ps1
@@ -31,7 +31,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.4'
+            ModuleVersion = '5.10.5'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/src/Catesta/Resources/Azure/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/Azure/actions_bootstrap.ps1
@@ -23,7 +23,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.4.0'
+            ModuleVersion = '5.5.0'
         }))
 '@
 }
@@ -31,7 +31,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.2'
+            ModuleVersion = '5.10.4'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/src/Catesta/Resources/Azure/azure-pipelines.yml
+++ b/src/Catesta/Resources/Azure/azure-pipelines.yml
@@ -24,7 +24,7 @@ if ($PLASTER_PARAM_AzureOptions -eq 'windows') {
       displayName: 'Build and Test - Windows PowerShell'
     - task: PublishTestResults@2
       inputs:
-        testRunner: 'NUnit'
+        testResultsFormat: 'NUnit'
         testResultsFiles: '**\Artifacts\testOutput\PesterTests.xml'
         testRunTitle: 'ps_winLatest'
         failTaskOnFailedTests: true
@@ -60,7 +60,7 @@ if ($PLASTER_PARAM_AzureOptions -eq 'pwshcore') {
       displayName: 'Build and Test - Windows pwsh'
     - task: PublishTestResults@2
       inputs:
-        testRunner: 'NUnit'
+        testResultsFormat: 'NUnit'
         testResultsFiles: '**\Artifacts\testOutput\PesterTests.xml'
         testRunTitle: 'pwsh_winLatest'
         failTaskOnFailedTests: true
@@ -96,7 +96,7 @@ if ($PLASTER_PARAM_AzureOptions -eq 'linux') {
       displayName: 'Build and Test - Linux'
     - task: PublishTestResults@2
       inputs:
-        testRunner: 'NUnit'
+        testResultsFormat: 'NUnit'
         testResultsFiles: '**/Artifacts/testOutput/PesterTests.xml'
         testRunTitle: 'pwsh_ubuntuLatest'
         failTaskOnFailedTests: true
@@ -132,7 +132,7 @@ if ($PLASTER_PARAM_AzureOptions -eq 'macos') {
       displayName: 'Build and Test - macOS'
     - task: PublishTestResults@2
       inputs:
-        testRunner: 'NUnit'
+        testResultsFormat: 'NUnit'
         testResultsFiles: '**/Artifacts/testOutput/PesterTests.xml'
         testRunTitle: 'pwsh_macOSLatest'
         failTaskOnFailedTests: true

--- a/src/Catesta/Resources/Bitbucket/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/Bitbucket/actions_bootstrap.ps1
@@ -7,12 +7,12 @@ Get-PackageProvider -Name Nuget -ForceBootstrap | Out-Null
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 
 # List of PowerShell Modules required for the build
-$modulesToInstall = [System.Collections.ArrayList]::new()
+$modulesToInstall = New-Object System.Collections.Generic.List[object]
 <%
 if ($PLASTER_PARAM_Pester-eq '4') {
 @'
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '4.10.1'
         }))
@@ -21,7 +21,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 elseif ($PLASTER_PARAM_Pester-eq '5') {
 @'
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '5.5.0'
         }))
@@ -29,18 +29,18 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 }
 %>
 # https://github.com/nightroman/Invoke-Build
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
             ModuleVersion = '5.10.5'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
             ModuleVersion = '1.21.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'platyPS'
             ModuleVersion = '0.12.0'
         }))
@@ -48,7 +48,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 <%
 if ($PLASTER_PARAM_VAULT -eq 'VAULT') {
     @'
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Microsoft.PowerShell.SecretManagement'
             ModuleVersion = '1.1.2'
         }))

--- a/src/Catesta/Resources/Bitbucket/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/Bitbucket/actions_bootstrap.ps1
@@ -31,7 +31,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.4'
+            ModuleVersion = '5.10.5'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/src/Catesta/Resources/Bitbucket/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/Bitbucket/actions_bootstrap.ps1
@@ -23,7 +23,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.4.0'
+            ModuleVersion = '5.5.0'
         }))
 '@
 }
@@ -31,7 +31,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.2'
+            ModuleVersion = '5.10.4'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
@@ -7,12 +7,12 @@ Get-PackageProvider -Name Nuget -ForceBootstrap | Out-Null
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 
 # List of PowerShell Modules required for the build
-$modulesToInstall = [System.Collections.ArrayList]::new()
+$modulesToInstall = New-Object System.Collections.Generic.List[object]
 <%
 if ($PLASTER_PARAM_Pester-eq '4') {
 @'
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '4.10.1'
         }))
@@ -21,7 +21,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 elseif ($PLASTER_PARAM_Pester-eq '5') {
 @'
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '5.5.0'
         }))
@@ -29,18 +29,18 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 }
 %>
 # https://github.com/nightroman/Invoke-Build
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
             ModuleVersion = '5.10.5'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
             ModuleVersion = '1.21.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'platyPS'
             ModuleVersion = '0.12.0'
         }))
@@ -48,7 +48,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 <%
 if ($PLASTER_PARAM_VAULT -eq 'VAULT') {
     @'
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Microsoft.PowerShell.SecretManagement'
             ModuleVersion = '1.1.2'
         }))

--- a/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
@@ -31,7 +31,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.4'
+            ModuleVersion = '5.10.5'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
@@ -23,7 +23,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.4.0'
+            ModuleVersion = '5.5.0'
         }))
 '@
 }
@@ -31,7 +31,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.2'
+            ModuleVersion = '5.10.4'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/src/Catesta/Resources/GitLab/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/GitLab/actions_bootstrap.ps1
@@ -7,12 +7,12 @@ Get-PackageProvider -Name Nuget -ForceBootstrap | Out-Null
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 
 # List of PowerShell Modules required for the build
-$modulesToInstall = [System.Collections.ArrayList]::new()
+$modulesToInstall = New-Object System.Collections.Generic.List[object]
 <%
 if ($PLASTER_PARAM_Pester-eq '4') {
 @'
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '4.10.1'
         }))
@@ -21,7 +21,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 elseif ($PLASTER_PARAM_Pester-eq '5') {
 @'
 # https://github.com/pester/Pester
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
             ModuleVersion = '5.5.0'
         }))
@@ -29,18 +29,18 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 }
 %>
 # https://github.com/nightroman/Invoke-Build
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
             ModuleVersion = '5.10.5'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
             ModuleVersion = '1.21.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'platyPS'
             ModuleVersion = '0.12.0'
         }))
@@ -48,7 +48,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 <%
 if ($PLASTER_PARAM_VAULT -eq 'VAULT') {
     @'
-$null = $modulesToInstall.Add(([PSCustomObject]@{
+[void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Microsoft.PowerShell.SecretManagement'
             ModuleVersion = '1.1.2'
         }))

--- a/src/Catesta/Resources/GitLab/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/GitLab/actions_bootstrap.ps1
@@ -31,7 +31,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.4'
+            ModuleVersion = '5.10.5'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/src/Catesta/Resources/GitLab/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/GitLab/actions_bootstrap.ps1
@@ -23,7 +23,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.4.0'
+            ModuleVersion = '5.5.0'
         }))
 '@
 }
@@ -31,7 +31,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.2'
+            ModuleVersion = '5.10.4'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{

--- a/src/Catesta/Resources/Module/plasterManifest.xml
+++ b/src/Catesta/Resources/Module/plasterManifest.xml
@@ -18,7 +18,7 @@
     <metadata>
         <name>Catesta</name>
         <id>258a61ba-566b-4c3a-8230-c2b6861a1a8d</id>
-        <version>2.0.0</version>
+        <version>2.0.2</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Module/plasterManifest.xml
+++ b/src/Catesta/Resources/Module/plasterManifest.xml
@@ -18,7 +18,7 @@
     <metadata>
         <name>Catesta</name>
         <id>258a61ba-566b-4c3a-8230-c2b6861a1a8d</id>
-        <version>2.0.2</version>
+        <version>2.2.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell module project</description>
         <author>Jake Morrison</author>
@@ -179,6 +179,7 @@
         <templateFile source='..\Module\src\PSModule.build.ps1' destination='src\${PLASTER_PARAM_ModuleName}.build.ps1'/>
         <file source='..\Module\src\PSModule.Settings.ps1' destination='src\${PLASTER_PARAM_ModuleName}.Settings.ps1'/>
         <file source='..\Module\src\PSScriptAnalyzerSettings.psd1' destination='src\PSScriptAnalyzerSettings.psd1'/>
+        <file condition="$PLASTER_PARAM_Help -eq 'Yes'" source='..\Module\src\MarkdownRepair.ps1' destination='src\MarkdownRepair.ps1' />
 
         <!-- VSCode files -->
         <templateFile source='..\Editor\VSCode\tasks.json' destination='.vscode\tasks.json' />

--- a/src/Catesta/Resources/Module/src/MarkdownRepair.ps1
+++ b/src/Catesta/Resources/Module/src/MarkdownRepair.ps1
@@ -1,0 +1,135 @@
+﻿<#
+.SYNOPSIS
+    Repair PlatyPS generated markdown files.
+.NOTES
+    This file is temporarily required to handle platyPS help generation.
+        https://github.com/PowerShell/platyPS/issues/595
+    This is a result of a breaking change introduced in PowerShell 7.4.0:
+        https://learn.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-powershell-74?view=powershell-7.4
+        Breaking Changes: Added the ProgressAction parameter to the Common Parameters
+    modified from source: https://github.com/PowerShell/platyPS/issues/595#issuecomment-1820971702
+#>
+
+function Remove-CommonParameterFromMarkdown {
+    <#
+    .SYNOPSIS
+        Remove a PlatyPS generated parameter block.
+    .DESCRIPTION
+        Removes parameter block for the provided parameter name from the markdown file provided.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $ParameterName = @('ProgressAction')
+    )
+    $ErrorActionPreference = 'Stop'
+    foreach ($p in $Path) {
+        $content = (Get-Content -Path $p -Raw).TrimEnd()
+        $updateFile = $false
+        foreach ($param in $ParameterName) {
+            if (-not ($Param.StartsWith('-'))) {
+                $param = "-$($param)"
+            }
+            # Remove the parameter block
+            $pattern = "(?m)^### $param\r?\n[\S\s]*?(?=#{2,3}?)"
+            $newContent = $content -replace $pattern, ''
+            # Remove the parameter from the syntax block
+            $pattern = " \[$param\s?.*?]"
+            $newContent = $newContent -replace $pattern, ''
+            if ($null -ne (Compare-Object -ReferenceObject $content -DifferenceObject $newContent)) {
+                Write-Verbose "Added $param to $p"
+                # Update file content
+                $content = $newContent
+                $updateFile = $true
+            }
+        }
+        # Save file if content has changed
+        if ($updateFile) {
+            $newContent | Out-File -Encoding utf8 -FilePath $p
+            Write-Verbose "Updated file: $p"
+        }
+    }
+    return
+}
+
+function Add-MissingCommonParameterToMarkdown {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $ParameterName = @('ProgressAction')
+    )
+    $ErrorActionPreference = 'Stop'
+    foreach ($p in $Path) {
+        $content = (Get-Content -Path $p -Raw).TrimEnd()
+        $updateFile = $false
+        foreach ($NewParameter in $ParameterName) {
+            if (-not ($NewParameter.StartsWith('-'))) {
+                $NewParameter = "-$($NewParameter)"
+            }
+            $pattern = '(?m)^This cmdlet supports the common parameters:(.+?)\.'
+            $replacement = {
+                $Params = $_.Groups[1].Captures[0].ToString() -split ' '
+                $CommonParameters = @()
+                foreach ($CommonParameter in $Params) {
+                    if ($CommonParameter.StartsWith('-')) {
+                        if ($CommonParameter.EndsWith(',')) {
+                            $CleanParam = $CommonParameter.Substring(0, $CommonParameter.Length - 1)
+                        }
+                        elseif ($p.EndsWith('.')) {
+                            $CleanParam = $CommonParameter.Substring(0, $CommonParameter.Length - 1)
+                        }
+                        else {
+                            $CleanParam = $CommonParameter
+                        }
+                        $CommonParameters += $CleanParam
+                    }
+                }
+                if ($NewParameter -notin $CommonParameters) {
+                    $CommonParameters += $NewParameter
+                }
+                $CommonParameters[-1] = "and $($CommonParameters[-1]). "
+                return "This cmdlet supports the common parameters: " + (($CommonParameters | Sort-Object) -join ', ')
+            }
+            $newContent = $content -replace $pattern, $replacement
+            if ($null -ne (Compare-Object -ReferenceObject $content -DifferenceObject $newContent)) {
+                Write-Verbose "Added $NewParameter to $p"
+                $updateFile = $true
+                $content = $newContent
+            }
+        }
+        # Save file if content has changed
+        if ($updateFile) {
+            $newContent | Out-File -Encoding utf8 -FilePath $p
+            Write-Verbose "Updated file: $p"
+        }
+    }
+    return
+}
+
+function Repair-PlatyPSMarkdown {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $Path,
+
+        [Parameter()]
+        [string[]]
+        $ParameterName = @('ProgressAction')
+    )
+    $ErrorActionPreference = 'Stop'
+    $Parameters = @{
+        Path          = $Path
+        ParameterName = $ParameterName
+    }
+    $null = Remove-CommonParameterFromMarkdown @Parameters
+    $null = Add-MissingCommonParameterToMarkdown @Parameters
+    return
+}

--- a/src/Catesta/Resources/Module/src/PSModule.build.ps1
+++ b/src/Catesta/Resources/Module/src/PSModule.build.ps1
@@ -535,6 +535,17 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
         throw 'Missing GUID. Please review and rebuild.'
     }
 
+    Write-Build Gray '           Evaluating if running 7.4.0 or higher...'
+    # https://github.com/PowerShell/platyPS/issues/595
+    if ($PSVersionTable.PSVersion -ge [version]'7.4.0') {
+        Write-Build Gray '               Performing Markdown repair'
+        # dot source markdown repair
+        . $BuildRoot\MarkdownRepair.ps1
+        $OutputDir | Get-ChildItem -File | ForEach-Object {
+            Repair-PlatyPSMarkdown -Path $_.FullName
+        }
+    }
+
     Write-Build Gray '           Checking for missing documentation in md files...'
     $MissingDocumentation = Select-String -Path "$script:ArtifactsPath\docs\*.md" -Pattern "({{.*}})"
     if ($MissingDocumentation.Count -gt 0) {

--- a/src/Catesta/Resources/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Vault/plasterManifest.xml
@@ -6,7 +6,7 @@
     <metadata>
         <name>Catesta</name>
         <id>d531e058-52b8-4dd2-8162-01c95d1eb8f7</id>
-        <version>2.0.2</version>
+        <version>2.2.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell SecretManagement extension vault module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Vault/plasterManifest.xml
@@ -6,7 +6,7 @@
     <metadata>
         <name>Catesta</name>
         <id>d531e058-52b8-4dd2-8162-01c95d1eb8f7</id>
-        <version>2.0.0</version>
+        <version>2.0.2</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell SecretManagement extension vault module project</description>
         <author>Jake Morrison</author>

--- a/src/MarkdownRepair.ps1
+++ b/src/MarkdownRepair.ps1
@@ -1,0 +1,135 @@
+﻿<#
+.SYNOPSIS
+    Repair PlatyPS generated markdown files.
+.NOTES
+    This file is temporarily required to handle platyPS help generation.
+        https://github.com/PowerShell/platyPS/issues/595
+    This is a result of a breaking change introduced in PowerShell 7.4.0:
+        https://learn.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-powershell-74?view=powershell-7.4
+        Breaking Changes: Added the ProgressAction parameter to the Common Parameters
+    modified from source: https://github.com/PowerShell/platyPS/issues/595#issuecomment-1820971702
+#>
+
+function Remove-CommonParameterFromMarkdown {
+    <#
+    .SYNOPSIS
+        Remove a PlatyPS generated parameter block.
+    .DESCRIPTION
+        Removes parameter block for the provided parameter name from the markdown file provided.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $ParameterName = @('ProgressAction')
+    )
+    $ErrorActionPreference = 'Stop'
+    foreach ($p in $Path) {
+        $content = (Get-Content -Path $p -Raw).TrimEnd()
+        $updateFile = $false
+        foreach ($param in $ParameterName) {
+            if (-not ($Param.StartsWith('-'))) {
+                $param = "-$($param)"
+            }
+            # Remove the parameter block
+            $pattern = "(?m)^### $param\r?\n[\S\s]*?(?=#{2,3}?)"
+            $newContent = $content -replace $pattern, ''
+            # Remove the parameter from the syntax block
+            $pattern = " \[$param\s?.*?]"
+            $newContent = $newContent -replace $pattern, ''
+            if ($null -ne (Compare-Object -ReferenceObject $content -DifferenceObject $newContent)) {
+                Write-Verbose "Added $param to $p"
+                # Update file content
+                $content = $newContent
+                $updateFile = $true
+            }
+        }
+        # Save file if content has changed
+        if ($updateFile) {
+            $newContent | Out-File -Encoding utf8 -FilePath $p
+            Write-Verbose "Updated file: $p"
+        }
+    }
+    return
+}
+
+function Add-MissingCommonParameterToMarkdown {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $ParameterName = @('ProgressAction')
+    )
+    $ErrorActionPreference = 'Stop'
+    foreach ($p in $Path) {
+        $content = (Get-Content -Path $p -Raw).TrimEnd()
+        $updateFile = $false
+        foreach ($NewParameter in $ParameterName) {
+            if (-not ($NewParameter.StartsWith('-'))) {
+                $NewParameter = "-$($NewParameter)"
+            }
+            $pattern = '(?m)^This cmdlet supports the common parameters:(.+?)\.'
+            $replacement = {
+                $Params = $_.Groups[1].Captures[0].ToString() -split ' '
+                $CommonParameters = @()
+                foreach ($CommonParameter in $Params) {
+                    if ($CommonParameter.StartsWith('-')) {
+                        if ($CommonParameter.EndsWith(',')) {
+                            $CleanParam = $CommonParameter.Substring(0, $CommonParameter.Length - 1)
+                        }
+                        elseif ($p.EndsWith('.')) {
+                            $CleanParam = $CommonParameter.Substring(0, $CommonParameter.Length - 1)
+                        }
+                        else {
+                            $CleanParam = $CommonParameter
+                        }
+                        $CommonParameters += $CleanParam
+                    }
+                }
+                if ($NewParameter -notin $CommonParameters) {
+                    $CommonParameters += $NewParameter
+                }
+                $CommonParameters[-1] = "and $($CommonParameters[-1]). "
+                return "This cmdlet supports the common parameters: " + (($CommonParameters | Sort-Object) -join ', ')
+            }
+            $newContent = $content -replace $pattern, $replacement
+            if ($null -ne (Compare-Object -ReferenceObject $content -DifferenceObject $newContent)) {
+                Write-Verbose "Added $NewParameter to $p"
+                $updateFile = $true
+                $content = $newContent
+            }
+        }
+        # Save file if content has changed
+        if ($updateFile) {
+            $newContent | Out-File -Encoding utf8 -FilePath $p
+            Write-Verbose "Updated file: $p"
+        }
+    }
+    return
+}
+
+function Repair-PlatyPSMarkdown {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $Path,
+
+        [Parameter()]
+        [string[]]
+        $ParameterName = @('ProgressAction')
+    )
+    $ErrorActionPreference = 'Stop'
+    $Parameters = @{
+        Path          = $Path
+        ParameterName = $ParameterName
+    }
+    $null = Remove-CommonParameterFromMarkdown @Parameters
+    $null = Add-MissingCommonParameterToMarkdown @Parameters
+    return
+}

--- a/src/Tests/Integration/FileChecks.Tests.ps1
+++ b/src/Tests/Integration/FileChecks.Tests.ps1
@@ -58,6 +58,10 @@ Describe 'File Checks' {
             $srcFiles.Name.Contains('PSModule.Settings.ps1') | Should -BeExactly $true
         } #it
 
+        It 'should have markdown repair file' {
+            $srcFiles.Name.Contains('MarkdownRepair.ps1') | Should -BeExactly $true
+        } #it
+
         It 'should have a PSScriptAnalyzerSettings file' {
             $srcFiles.Name.Contains('PSScriptAnalyzerSettings.psd1') | Should -BeExactly $true
         } #it

--- a/src/Tests/Integration/New-ModuleProject.Tests.ps1
+++ b/src/Tests/Integration/New-ModuleProject.Tests.ps1
@@ -70,6 +70,7 @@ Describe 'Module Integration Tests' {
                     $moduleOnlyFiles.Name.Contains('Imports.ps1') | Should -BeExactly $true
                     $moduleOnlyFiles.Name.Contains('modulename.build.ps1') | Should -BeExactly $true
                     $moduleOnlyFiles.Name.Contains('modulename.Settings.ps1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('MarkdownRepair.ps1') | Should -BeExactly $true
                     $moduleOnlyFiles.Name.Contains('PSScriptAnalyzerSettings.psd1') | Should -BeExactly $true
                     $moduleOnlyFiles.Name.Contains('Get-HelloWorld.ps1') | Should -BeExactly $true
                     $moduleOnlyFiles.Name.Contains('Get-Day.ps1') | Should -BeExactly $true
@@ -136,6 +137,31 @@ Describe 'Module Integration Tests' {
 
                     # Help
                     $buildContent | Should -BeLike '*CreateHelpStart*'
+
+                } #it
+
+                It 'should generate a module only scaffold with base elements with no MarkdownRepair if help is not selected' {
+                    $moduleParameters = @{
+                        VAULT       = 'text'
+                        ModuleName  = 'modulename'
+                        Description = 'text'
+                        Version     = '0.0.1'
+                        FN          = 'user full name'
+                        CICD        = 'NONE'
+                        RepoType    = 'NONE'
+                        CodingStyle = 'Stroustrup'
+                        Help        = 'No'
+                        Pester      = '5'
+                        S3Bucket    = 'PSGallery'
+                        PassThru    = $true
+                        NoLogo      = $true
+                    }
+                    $eval = New-ModuleProject -ModuleParameters $moduleParameters -DestinationPath $outPutPath
+                    $eval | Should -Not -BeNullOrEmpty
+
+                    $moduleOnlyFiles = Get-ChildItem -Path $outPutPathStar -Recurse -Force
+
+                    $moduleOnlyFiles.Name.Contains('MarkdownRepair.ps1') | Should -BeExactly $false
 
                 } #it
 


### PR DESCRIPTION
# Pull Request

## Issue

Fixes #71 

## Description

Description of changes:

- Catesta template module changes
    - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script. This is to account for an issue in PowerShell `7.4.0`+ where a new parameter was introduced that platyPS can not handle during help creation. Ref: [platyPS issue]([text](https://github.com/PowerShell/platyPS/issues/595)).
        - If a build is run and the build environment is `7.4.0`+ the Markdown repair will run to account for the new parameter and repair markdown for help creation.
    - Replaced uses of `System.Collections.ArrayList` with `System.Collections.Generic.List` throughout.
    - CI/CD Changes:
        - Azure:
            - Updated `testRunner` alias reference to `testResultsFormat`
        - AWS CodeBuild CI/CD changes:
            - `PowerShellCodeBuildCC.yml`
                - `aws/codebuild/standard:6.0` to `aws/codebuild/standard:7.0`
            - `PowerShellCodeBuildGit.yml`
                - `aws/codebuild/standard:6.0` to `aws/codebuild/standard:7.0`
        - Plaster bumped from `1.1.3` to `1.1.4`
        - Pester bumped from `5.4.0` to `5.5.0`
        - InvokeBuild bumped from `5.10.2` to `5.10.5`
- Catesta primary module changes
    - Added `MarkdownRepair.ps1` and added Markdown repair logic to InvokeBuild script.
    - Updated `LicenseUri` and `IconUri` link in `psd1` manifest.
    - Updated link references in inline help for both public functions
    - Replaced uses of `System.Collections.ArrayList` with `System.Collections.Generic.List` throughout.
    - Plaster bumped from `1.1.3` to `1.1.4`
    - Pester bumped from `5.4.0` to `5.5.0`
    - InvokeBuild bumped from `5.10.2` to `5.10.5`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
