### PR TITLE
Enhancements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0]
+
+- Catesta template module changes
+    - Catesta now supports namespaced modules (ex. `MyModule.Utils` )
+- Catesta primary module changes
+    - Updated build file to use new regex pattern for deriving module name
+    - Added tests for namespaced module creation
+
 ## [2.2.0]
 
 - Catesta template module changes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.0]
+## [2.4.0]
 
 - Catesta template module changes
     - Catesta now supports namespaced modules (ex. `MyModule.Utils` )
+    - CI/CD Changes:
+        - Azure:
+            - Updated `PublishCodeCoverageResults@1` to `PublishCodeCoverageResults@2`
 - Catesta primary module changes
     - Updated build file to use new regex pattern for deriving module name
     - Added tests for namespaced module creation

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 2.2.0
+Help Version: 2.3.0
 Locale: en-US
 ---
 

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 2.3.0
+Help Version: 2.4.0
 Locale: en-US
 ---
 

--- a/src/Catesta.build.ps1
+++ b/src/Catesta.build.ps1
@@ -38,7 +38,7 @@
 #>
 
 #Include: Settings
-$ModuleName = (Split-Path -Path $BuildFile -Leaf).Split('.')[0]
+$ModuleName = [regex]::Match((Get-Item $BuildFile).Name, '^(.*)\.build\.ps1$').Groups[1].Value
 . "./$ModuleName.Settings.ps1"
 
 function Test-ManifestBool ($Path) {
@@ -67,7 +67,7 @@ Add-BuildTask BuildNoIntegration -Jobs $str2
 
 # Pre-build variables to be used by other portions of the script
 Enter-Build {
-    $script:ModuleName = (Split-Path -Path $BuildFile -Leaf).Split('.')[0]
+    $script:ModuleName = [regex]::Match((Get-Item $BuildFile).Name, '^(.*)\.build\.ps1$').Groups[1].Value
 
     # Identify other required paths
     $script:ModuleSourcePath = Join-Path -Path $BuildRoot -ChildPath $script:ModuleName

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.2.0'
+    ModuleVersion     = '2.3.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.3.0'
+    ModuleVersion     = '2.4.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Resources/Azure/azure-pipelines.yml
+++ b/src/Catesta/Resources/Azure/azure-pipelines.yml
@@ -29,7 +29,7 @@ if ($PLASTER_PARAM_AzureOptions -eq 'windows') {
         testRunTitle: 'ps_winLatest'
         failTaskOnFailedTests: true
       displayName: "Publish Unit Test Results - Windows PowerShell"
-    - task: PublishCodeCoverageResults@1
+    - task: PublishCodeCoverageResults@2
       inputs:
         summaryFileLocation: '**\Artifacts\ccReport\CodeCoverage.xml'
         pathToSources: '$(System.DefaultWorkingDirectory)\src\Artifacts\ccReport'
@@ -65,7 +65,7 @@ if ($PLASTER_PARAM_AzureOptions -eq 'pwshcore') {
         testRunTitle: 'pwsh_winLatest'
         failTaskOnFailedTests: true
       displayName: "Publish Unit Test Results - Windows pwsh"
-    - task: PublishCodeCoverageResults@1
+    - task: PublishCodeCoverageResults@2
       inputs:
         summaryFileLocation: '**\Artifacts\ccReport\CodeCoverage.xml'
         pathToSources: '$(System.DefaultWorkingDirectory)\src\Artifacts\ccReport'
@@ -101,7 +101,7 @@ if ($PLASTER_PARAM_AzureOptions -eq 'linux') {
         testRunTitle: 'pwsh_ubuntuLatest'
         failTaskOnFailedTests: true
       displayName: "Publish Unit Test Results - Linux"
-    - task: PublishCodeCoverageResults@1
+    - task: PublishCodeCoverageResults@2
       inputs:
         summaryFileLocation: '**/Artifacts/ccReport/CodeCoverage.xml'
         pathToSources: '$(System.DefaultWorkingDirectory)/src/Artifacts/ccReport'
@@ -137,7 +137,7 @@ if ($PLASTER_PARAM_AzureOptions -eq 'macos') {
         testRunTitle: 'pwsh_macOSLatest'
         failTaskOnFailedTests: true
       displayName: "Publish Unit Test Results - macOS"
-    - task: PublishCodeCoverageResults@1
+    - task: PublishCodeCoverageResults@2
       inputs:
         summaryFileLocation: '**/Artifacts/ccReport/CodeCoverage.xml'
         pathToSources: '$(System.DefaultWorkingDirectory)/src/Artifacts/ccReport'

--- a/src/Catesta/Resources/Module/plasterManifest.xml
+++ b/src/Catesta/Resources/Module/plasterManifest.xml
@@ -18,7 +18,7 @@
     <metadata>
         <name>Catesta</name>
         <id>258a61ba-566b-4c3a-8230-c2b6861a1a8d</id>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Module/plasterManifest.xml
+++ b/src/Catesta/Resources/Module/plasterManifest.xml
@@ -18,7 +18,7 @@
     <metadata>
         <name>Catesta</name>
         <id>258a61ba-566b-4c3a-8230-c2b6861a1a8d</id>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Module/src/PSModule.build.ps1
+++ b/src/Catesta/Resources/Module/src/PSModule.build.ps1
@@ -38,7 +38,7 @@
 #>
 
 #Include: Settings
-$ModuleName = (Split-Path -Path $BuildFile -Leaf).Split('.')[0]
+$ModuleName = [regex]::Match((Get-Item $BuildFile).Name, '^(.*)\.build\.ps1$').Groups[1].Value
 . "./$ModuleName.Settings.ps1"
 
 function Test-ManifestBool ($Path) {
@@ -79,7 +79,7 @@ Add-BuildTask BuildNoIntegration -Jobs $str2
 
 # Pre-build variables to be used by other portions of the script
 Enter-Build {
-    $script:ModuleName = (Split-Path -Path $BuildFile -Leaf).Split('.')[0]
+    $script:ModuleName = [regex]::Match((Get-Item $BuildFile).Name, '^(.*)\.build\.ps1$').Groups[1].Value
 
     # Identify other required paths
     $script:ModuleSourcePath = Join-Path -Path $BuildRoot -ChildPath $script:ModuleName

--- a/src/Catesta/Resources/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Vault/plasterManifest.xml
@@ -6,7 +6,7 @@
     <metadata>
         <name>Catesta</name>
         <id>d531e058-52b8-4dd2-8162-01c95d1eb8f7</id>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell SecretManagement extension vault module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Vault/plasterManifest.xml
@@ -6,7 +6,7 @@
     <metadata>
         <name>Catesta</name>
         <id>d531e058-52b8-4dd2-8162-01c95d1eb8f7</id>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell SecretManagement extension vault module project</description>
         <author>Jake Morrison</author>

--- a/src/Tests/Integration/New-ModuleProject.Tests.ps1
+++ b/src/Tests/Integration/New-ModuleProject.Tests.ps1
@@ -165,6 +165,46 @@ Describe 'Module Integration Tests' {
 
                 } #it
 
+                It 'should generate a namespaced module only scaffold with base elements' {
+                    $moduleParameters = @{
+                        VAULT       = 'text'
+                        ModuleName  = 'module.name'
+                        Description = 'text'
+                        Version     = '0.0.1'
+                        FN          = 'user full name'
+                        CICD        = 'NONE'
+                        RepoType    = 'NONE'
+                        CodingStyle = 'Stroustrup'
+                        Help        = 'Yes'
+                        Pester      = '5'
+                        S3Bucket    = 'PSGallery'
+                        PassThru    = $true
+                        NoLogo      = $true
+                    }
+                    $eval = New-ModuleProject -ModuleParameters $moduleParameters -DestinationPath $outPutPath
+                    $eval | Should -Not -BeNullOrEmpty
+
+                    $moduleOnlyFiles = Get-ChildItem -Path $outPutPathStar -Recurse -Force
+
+                    # MODULE
+                    $moduleOnlyFiles.Name.Contains('module.name.psd1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('module.name.psm1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('Imports.ps1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('module.name.build.ps1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('module.name.Settings.ps1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('MarkdownRepair.ps1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('PSScriptAnalyzerSettings.psd1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('Get-HelloWorld.ps1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('Get-Day.ps1') | Should -BeExactly $true
+
+                    # Tests
+                    $moduleOnlyFiles.Name.Contains('SampleIntegrationTest.Tests.ps1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('ExportedFunctions.Tests.ps1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('module.name-Module.Tests.ps1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('Get-HelloWorld.Tests.ps1') | Should -BeExactly $true
+                    $moduleOnlyFiles.Name.Contains('Get-Day.Tests.ps1') | Should -BeExactly $true
+                } #it
+
             } #context_module_only
 
             Context 'AWS-CodeBuild' {


### PR DESCRIPTION
# Pull Request

## Issue

#73 , #74

## Description

- Catesta template module changes
    - Catesta now supports namespaced modules (ex. `MyModule.Utils` )
    - CI/CD Changes:
        - Azure:
            - Updated `PublishCodeCoverageResults@1` to `PublishCodeCoverageResults@2`
- Catesta primary module changes
    - Updated build file to use new regex pattern for deriving module name
    - Added tests for namespaced module creation

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
