### PR TITLE
Enhancements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 mkdocs:
   configuration: mkdocs.yml

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0]
+
+- Catesta template module changes
+    - readthedocs updates:
+        - Updated `requirements.txt`
+            - `jinja2 3.0.3`  to `jinja2 3.1.4`
+            - `mkdocs 1.4.2` to `mkdocs 1.6.0`
+            - `mkdocs-material 9.0.12` to `mkdocs-material 9.5.25`
+            - `pygments 2.14.0` to `pygments 2.18.0`
+        - Updated `.readthedocs.yaml`
+            - `python 3.11` to `python 3.12`
+- Catesta primary module changes
+    - readthedocs updates:
+        - Updated `requirements.txt`
+            - `jinja2 3.0.3`  to `jinja2 3.1.4`
+            - `mkdocs 1.4.2` to `mkdocs 1.6.0`
+            - `mkdocs-material 9.0.12` to `mkdocs-material 9.5.25`
+            - `pygments 2.14.0` to `pygments 2.18.0`
+        - Updated `.readthedocs.yaml`
+            - `python 3.11` to `python 3.12`
+
 ## [2.11.0]
 
 - Catesta template module changes

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 2.11.0
+Help Version: 2.12.0
 Locale: en-US
 ---
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 # https://github.com/readthedocs-examples/example-mkdocs-basic/blob/main/docs/requirements.txt
 # requirements.txt
-jinja2==3.0.3
-mkdocs>=1.4.2
-mkdocs-material==9.0.12  #https://github.com/squidfunk/mkdocs-material
-pygments>=2.14.0
+jinja2==3.1.4  #https://pypi.org/project/Jinja2/
+mkdocs>=1.6.0  #https://github.com/mkdocs/mkdocs
+mkdocs-material==9.5.25  #https://github.com/squidfunk/mkdocs-material
+pygments>=2.18.0  #https://pypi.org/project/Pygments/
 # mdx_truly_sane_lists

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.11.0'
+    ModuleVersion     = '2.12.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Resources/Module/plasterManifest.xml
+++ b/src/Catesta/Resources/Module/plasterManifest.xml
@@ -18,7 +18,7 @@
     <metadata>
         <name>Catesta</name>
         <id>258a61ba-566b-4c3a-8230-c2b6861a1a8d</id>
-        <version>2.11.0</version>
+        <version>2.12.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Read_the_Docs/.readthedocs.yaml
+++ b/src/Catesta/Resources/Read_the_Docs/.readthedocs.yaml
@@ -10,7 +10,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 mkdocs:
   configuration: mkdocs.yml

--- a/src/Catesta/Resources/Read_the_Docs/material/requirements.txt
+++ b/src/Catesta/Resources/Read_the_Docs/material/requirements.txt
@@ -1,7 +1,7 @@
 # https://github.com/readthedocs-examples/example-mkdocs-basic/blob/main/docs/requirements.txt
 # requirements.txt
-jinja2==3.0.3
-mkdocs>=1.4.2
-mkdocs-material>=9.0.12  #https://github.com/squidfunk/mkdocs-material
-pygments>=2.14.0
+jinja2==3.1.4  #https://pypi.org/project/Jinja2/
+mkdocs>=1.6.0  #https://github.com/mkdocs/mkdocs
+mkdocs-material==9.5.25  #https://github.com/squidfunk/mkdocs-material
+pygments>=2.18.0  #https://pypi.org/project/Pygments/
 # mdx_truly_sane_lists

--- a/src/Catesta/Resources/Read_the_Docs/readthedocs/requirements.txt
+++ b/src/Catesta/Resources/Read_the_Docs/readthedocs/requirements.txt
@@ -1,4 +1,4 @@
 # https://github.com/readthedocs-examples/example-mkdocs-basic/blob/main/docs/requirements.txt
 # requirements.txt
-jinja2==3.0.3
-mkdocs>=1.4.2
+jinja2==3.1.4  #https://pypi.org/project/Jinja2/
+mkdocs>=1.6.0  #https://github.com/mkdocs/mkdocs

--- a/src/Catesta/Resources/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Vault/plasterManifest.xml
@@ -6,7 +6,7 @@
     <metadata>
         <name>Catesta</name>
         <id>d531e058-52b8-4dd2-8162-01c95d1eb8f7</id>
-        <version>2.11.0</version>
+        <version>2.12.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell SecretManagement extension vault module project</description>
         <author>Jake Morrison</author>


### PR DESCRIPTION
# Pull Request

## Description

- Catesta template module changes
    - readthedocs updates:
        - Updated `requirements.txt`
            - `jinja2 3.0.3`  to `jinja2 3.1.4`
            - `mkdocs 1.4.2` to `mkdocs 1.6.0`
            - `mkdocs-material 9.0.12` to `mkdocs-material 9.5.25`
            - `pygments 2.14.0` to `pygments 2.18.0`
        - Updated `.readthedocs.yaml`
            - `python 3.11` to `python 3.12`
- Catesta primary module changes
    - readthedocs updates:
        - Updated `requirements.txt`
            - `jinja2 3.0.3`  to `jinja2 3.1.4`
            - `mkdocs 1.4.2` to `mkdocs 1.6.0`
            - `mkdocs-material 9.0.12` to `mkdocs-material 9.5.25`
            - `pygments 2.14.0` to `pygments 2.18.0`
        - Updated `.readthedocs.yaml`
            - `python 3.11` to `python 3.12`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
