### PR TITLE
adjusted tests for BeforeDiscovery use

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.21.0]
+
+- Catesta template module changes
+    - Unit and infra tests changed from use of import using `BeforeAll` to `BeforeDiscovery`
+- Catesta primary module changes
+    - Unit and infra tests changed from use of import using `BeforeAll` to `BeforeDiscovery`
+
 ## [2.20.0]
 
 - Catesta template module changes

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 2.20.0
+Help Version: 2.21.0
 Locale: en-US
 ---
 

--- a/src/Catesta.build.ps1
+++ b/src/Catesta.build.ps1
@@ -271,7 +271,7 @@ Add-BuildTask Test {
             $pesterConfiguration.CodeCoverage.Path = "/Users/runner/work/$ModuleName/$ModuleName/src/$ModuleName/*/*.ps1"
         }
         else {
-            $pesterConfiguration.CodeCoverage.Path = "..\..\..\src\$ModuleName\*\*.ps1"
+            $pesterConfiguration.CodeCoverage.Path = "..\..\..\$ModuleName\*\*.ps1"
         }
         $pesterConfiguration.TestResult.Enabled = $true
         $pesterConfiguration.TestResult.OutputPath = "$testOutPutPath\PesterTests.xml"

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.20.0'
+    ModuleVersion     = '2.21.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Resources/Module/src/PSModule.build.ps1
+++ b/src/Catesta/Resources/Module/src/PSModule.build.ps1
@@ -353,7 +353,7 @@ elseif ($PLASTER_PARAM_Pester -eq '5') {
         $pesterConfiguration.Run.PassThru = $true
         $pesterConfiguration.Run.Exit = $false
         $pesterConfiguration.CodeCoverage.Enabled = $true
-        $pesterConfiguration.CodeCoverage.Path = "..\..\..\src\$ModuleName\*\*.ps1"
+        $pesterConfiguration.CodeCoverage.Path = "..\..\..\$ModuleName\*\*.ps1"
         $pesterConfiguration.CodeCoverage.CoveragePercentTarget = $script:coverageThreshold
         $pesterConfiguration.CodeCoverage.OutputPath = "$codeCovPath\CodeCoverage.xml"
         $pesterConfiguration.CodeCoverage.OutputFormat = 'JaCoCo'

--- a/src/Catesta/Resources/Module/src/Tests/v5/Unit/Private/Private-Function.Tests.ps1
+++ b/src/Catesta/Resources/Module/src/Tests/v5/Unit/Private/Private-Function.Tests.ps1
@@ -1,4 +1,4 @@
-BeforeAll {
+BeforeDiscovery {
     Set-Location -Path $PSScriptRoot
     $ModuleName = '<%=$PLASTER_PARAM_ModuleName%>'
     $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")

--- a/src/Catesta/Resources/Module/src/Tests/v5/Unit/Public/Public-Function.Tests.ps1
+++ b/src/Catesta/Resources/Module/src/Tests/v5/Unit/Public/Public-Function.Tests.ps1
@@ -1,4 +1,4 @@
-BeforeAll {
+BeforeDiscovery {
     Set-Location -Path $PSScriptRoot
     $ModuleName = '<%=$PLASTER_PARAM_ModuleName%>'
     $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")

--- a/src/Catesta/Resources/Vault/src/Tests/v5/Unit/ExportedFunctions.Tests.ps1
+++ b/src/Catesta/Resources/Vault/src/Tests/v5/Unit/ExportedFunctions.Tests.ps1
@@ -1,4 +1,4 @@
-BeforeAll {
+BeforeDiscovery {
     Set-Location -Path $PSScriptRoot
     $ModuleName = '<%=$PLASTER_PARAM_ModuleName%>'
     $PathToManifest = [System.IO.Path]::Combine('..', '..', $ModuleName, "$ModuleName.psd1")

--- a/src/Catesta/Resources/Vault/src/Tests/v5/Unit/Module-Function.Tests.ps1
+++ b/src/Catesta/Resources/Vault/src/Tests/v5/Unit/Module-Function.Tests.ps1
@@ -1,4 +1,4 @@
-BeforeAll {
+BeforeDiscovery {
     Set-Location -Path $PSScriptRoot
     $ModuleName = '<%=$PLASTER_PARAM_ModuleName%>'
     $vaultName = '<%=$PLASTER_PARAM_ModuleName%>'

--- a/src/Tests/Integration/New-ModuleProject.Tests.ps1
+++ b/src/Tests/Integration/New-ModuleProject.Tests.ps1
@@ -1,4 +1,4 @@
-BeforeAll {
+BeforeDiscovery {
     Set-Location -Path $PSScriptRoot
     $ModuleName = 'Catesta'
     $PathToManifest = [System.IO.Path]::Combine('..', '..', 'Artifacts', "$ModuleName.psd1")

--- a/src/Tests/Integration/New-VaultProject.Tests.ps1
+++ b/src/Tests/Integration/New-VaultProject.Tests.ps1
@@ -1,4 +1,4 @@
-BeforeAll {
+BeforeDiscovery {
     Set-Location -Path $PSScriptRoot
     $ModuleName = 'Catesta'
     $PathToManifest = [System.IO.Path]::Combine('..', '..', 'Artifacts', "$ModuleName.psd1")

--- a/src/Tests/Unit/Public/New-ModuleProject.Tests.ps1
+++ b/src/Tests/Unit/Public/New-ModuleProject.Tests.ps1
@@ -1,4 +1,4 @@
-BeforeAll {
+BeforeDiscovery {
     Set-Location -Path $PSScriptRoot
     $ModuleName = 'Catesta'
     $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")

--- a/src/Tests/Unit/Public/New-VaultProject.Tests.ps1
+++ b/src/Tests/Unit/Public/New-VaultProject.Tests.ps1
@@ -1,4 +1,4 @@
-BeforeAll {
+BeforeDiscovery {
     Set-Location -Path $PSScriptRoot
     $ModuleName = 'Catesta'
     $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")


### PR DESCRIPTION
# Pull Request

## Issue

Fixes #92 

## Description

- Catesta template module changes
    - Unit and infra tests changed from use of import using `BeforeAll` to `BeforeDiscovery`
- Catesta primary module changes
    - Unit and infra tests changed from use of import using `BeforeAll` to `BeforeDiscovery`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
