### PR TITLE
Enhancement - Windows PowerShell 5.1 compatibility

### DIFF
--- a/actions_bootstrap.ps1
+++ b/actions_bootstrap.ps1
@@ -46,7 +46,7 @@ foreach ($module in $modulesToInstall) {
         ErrorAction     = 'Stop'
     }
     try {
-        if ($module.ModuleName -eq 'Pester' -and $IsWindows) {
+        if ($module.ModuleName -eq 'Pester' -and ($IsWindows -or $PSVersionTable.PSVersion -ge [version]'5.1')) {
             # special case for Pester certificate mismatch with older Pester versions - https://github.com/pester/Pester/issues/2389
             # this only affects windows builds
             Install-Module @installSplat -SkipPublisherCheck


### PR DESCRIPTION
# Pull Request

## Description

Enhanced **actions_bootstrap.ps1** to support Windows PowerShell 5.1 while installing Pester on Windows. It currently checks for `$IsWindows`, which was only introduced in PowerShell 6.

I updated it to `-and ($IsWindows -or $PSVersionTable.PSVersion -ge [version]'5.1')` but if minimal code is desired, it could be further simplified to `-and $PSVersionTable.PSVersion -ge [version]'5.1')`.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
