### PR TITLE
Invoke-Formatter after building PSM1 file

### DIFF
--- a/src/Catesta.build.ps1
+++ b/src/Catesta.build.ps1
@@ -503,6 +503,8 @@ Add-BuildTask Build {
         $null = $scriptContent.AppendLine('')
     }
     $scriptContent.ToString() | Out-File -FilePath $script:BuildModuleRootFile -Encoding utf8 -Force
+    # Cleanup the combined root module and remove extra trailing lines at the end of the file.
+    Invoke-Formatter $script:BuildModuleRootFile -ErrorAction SilentlyContinue
     Write-Build Gray '        ...Module creation complete.'
 
     #here we update the parent level docs. If you would prefer not to update them, comment out this section.

--- a/src/Catesta/Resources/Module/src/PSModule.build.ps1
+++ b/src/Catesta/Resources/Module/src/PSModule.build.ps1
@@ -636,6 +636,8 @@ Add-BuildTask Build {
         $null = $scriptContent.AppendLine('')
     }
     $scriptContent.ToString() | Out-File -FilePath $script:BuildModuleRootFile -Encoding utf8 -Force
+    # Cleanup the combined root module and remove extra trailing lines at the end of the file.
+    Invoke-Formatter $script:BuildModuleRootFile -ErrorAction SilentlyContinue
     Write-Build Gray '        ...Module creation complete.'
 
     Write-Build Gray '        Cleaning up leftover artifacts...'


### PR DESCRIPTION
## Description

The script block that builds the PSM1 file results in several extra trailing lines at the end of the file. By adding `Invoke-Formatter` at the end of this section, it removes those lines and cleans up any other formatting errors that may have been introduced.

* [`src/Catesta.build.ps1`](diffhunk://#diff-04160eddf2032e2b5c489009e44a5d662dcfa4ededd3691e3cf37d089f8a3edbR506-R507): Added `Invoke-Formatter` command to clean up the combined root module and remove extra trailing lines at the end of the file.
* [`src/Catesta/Resources/Module/src/PSModule.build.ps1`](diffhunk://#diff-c5640e8dea73feb15a158b7af904c4b701e0c262248f9a45375655c6eaa9a46bR639-R640): Added `Invoke-Formatter` command to clean up the combined root module and remove extra trailing lines at the end of the file.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
