### PR TITLE
Enhancements

### DIFF
--- a/.github/workflows/wf_Linux.yml
+++ b/.github/workflows/wf_Linux.yml
@@ -41,13 +41,13 @@ jobs:
       shell: pwsh
       run: Invoke-Build -File .\src\Catesta.build.ps1
     - name: Upload pester results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pester-results
         path: ./src/Artifacts/testOutput
         if-no-files-found: warn
     - name: Upload zip module archive build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: zip-archive
         path: ./src/Archive

--- a/.github/workflows/wf_MacOS.yml
+++ b/.github/workflows/wf_MacOS.yml
@@ -41,13 +41,13 @@ jobs:
       shell: pwsh
       run: Invoke-Build -File .\src\Catesta.build.ps1
     - name: Upload pester results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pester-results
         path: ./src/Artifacts/testOutput
         if-no-files-found: warn
     - name: Upload zip module archive build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: zip-archive
         path: ./src/Archive

--- a/.github/workflows/wf_Windows.yml
+++ b/.github/workflows/wf_Windows.yml
@@ -41,13 +41,13 @@ jobs:
       shell: powershell
       run: Invoke-Build -File .\src\Catesta.build.ps1
     - name: Upload pester results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pester-results
         path: .\src\Artifacts\testOutput
         if-no-files-found: warn
     - name: Upload zip module archive build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: zip-archive
         path: .\src\Archive

--- a/.github/workflows/wf_Windows_Core.yml
+++ b/.github/workflows/wf_Windows_Core.yml
@@ -41,13 +41,13 @@ jobs:
       shell: pwsh
       run: Invoke-Build -File .\src\Catesta.build.ps1
     - name: Upload pester results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pester-results
         path: .\src\Artifacts\testOutput
         if-no-files-found: warn
     - name: Upload zip module archive build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: zip-archive
         path: .\src\Archive

--- a/actions_bootstrap.ps1
+++ b/actions_bootstrap.ps1
@@ -16,17 +16,17 @@ $modulesToInstall = New-Object System.Collections.Generic.List[object]
 # https://github.com/pester/Pester
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.6.1'
+            ModuleVersion = '5.7.1'
         }))
 # https://github.com/nightroman/Invoke-Build
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.11.3'
+            ModuleVersion = '5.12.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.22.0'
+            ModuleVersion = '1.23.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.23.0]
+
+- Catesta template module changes
+    - Updated all GitHub actions workflows from `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
+- Catesta primary module changes
+    - Updated GitHub actions workflows from `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
+
 ## [2.22.2]
 
 - Catesta template module changes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,18 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.24.0]
+## [2.27.0]
 
 - Catesta template module changes
     - Updated all GitHub actions workflows from `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
-    - `Invoke-Formatter` now runs at the end of `Build` step for final cleanup
+    - `*.build.ps1` Improvements:
+        - `Invoke-Formatter` now runs at the end of `Build` step for final cleanup
+        - Added new Markdown processing functionality to address two Markdown linting issues:
+            - `MD022/blanks-around-headings`
+            - `MD040/fenced-code-language`
     - CI/CD Changes:
         - Pester bumped from `5.6.1` to `5.7.1`
         - InvokeBuild bumped from `5.11.3` to `5.12.1`
         - PSScriptAnalyzer bumped from `1.22.0` to `1.23.0`
 - Catesta primary module changes
     - Updated GitHub actions workflows from `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
-    - `Invoke-Formatter` now runs at the end of `Build` step for final cleanup
+    - `Catesta.build.ps1` Improvements:
+        - `Invoke-Formatter` now runs at the end of `Build` step for final cleanup
+        - Added new Markdown processing functionality to address two Markdown linting issues:
+            - `MD022/blanks-around-headings`
+            - `MD040/fenced-code-language`
     - Pester bumped from `5.6.1` to `5.7.1`
     - InvokeBuild bumped from `5.11.3` to `5.12.1`
     - PSScriptAnalyzer bumped from `1.22.0` to `1.23.0`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - Added new Markdown processing functionality to address two Markdown linting issues:
             - `MD022/blanks-around-headings`
             - `MD040/fenced-code-language`
+        - Added more detailed error output to `ImportModuleManifest`
     - CI/CD Changes:
         - Pester bumped from `5.6.1` to `5.7.1`
         - InvokeBuild bumped from `5.11.3` to `5.12.1`
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - Added new Markdown processing functionality to address two Markdown linting issues:
             - `MD022/blanks-around-headings`
             - `MD040/fenced-code-language`
+        - Added more detailed error output to `ImportModuleManifest`
     - Pester bumped from `5.6.1` to `5.7.1`
     - InvokeBuild bumped from `5.11.3` to `5.12.1`
     - PSScriptAnalyzer bumped from `1.22.0` to `1.23.0`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.23.0]
+## [2.24.0]
 
 - Catesta template module changes
     - Updated all GitHub actions workflows from `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
+    - CI/CD Changes:
+        - Pester bumped from `5.6.1` to `5.7.1`
+        - InvokeBuild bumped from `5.11.3` to `5.12.1`
+        - PSScriptAnalyzer bumped from `1.22.0` to `1.23.0`
 - Catesta primary module changes
     - Updated GitHub actions workflows from `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
+    - Pester bumped from `5.6.1` to `5.7.1`
+    - InvokeBuild bumped from `5.11.3` to `5.12.1`
+    - PSScriptAnalyzer bumped from `1.22.0` to `1.23.0`
 
 ## [2.22.2]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Catesta template module changes
     - Updated all GitHub actions workflows from `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
+    - `Invoke-Formatter` now runs at the end of `Build` step for final cleanup
     - CI/CD Changes:
         - Pester bumped from `5.6.1` to `5.7.1`
         - InvokeBuild bumped from `5.11.3` to `5.12.1`
         - PSScriptAnalyzer bumped from `1.22.0` to `1.23.0`
 - Catesta primary module changes
     - Updated GitHub actions workflows from `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
+    - `Invoke-Formatter` now runs at the end of `Build` step for final cleanup
     - Pester bumped from `5.6.1` to `5.7.1`
     - InvokeBuild bumped from `5.11.3` to `5.12.1`
     - PSScriptAnalyzer bumped from `1.22.0` to `1.23.0`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.22.2]
+
+- Catesta template module changes
+    - Added PSScriptAnalyzer suppression rule to `MarkdownRepair.ps1`
+- Catesta primary module changes
+    - Addressed bug in `Catesta.build.ps1` where in certain circumstances PSScriptAnalyzer violations were not being properly detected
+    - Added PSScriptAnalyzer suppression rule to `MarkdownRepair.ps1`
+
 ## [2.22.0]
 
 - Catesta template module changes

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 2.23.0
+Help Version: 2.24.0
 Locale: en-US
 ---
 

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 2.24.0
+Help Version: 2.27.0
 Locale: en-US
 ---
 
@@ -16,5 +16,3 @@ Scaffolds a PowerShell module project for use with desired CICD platform for eas
 
 ### [New-VaultProject](New-VaultProject.md)
 Scaffolds a PowerShell SecretManagement vault project for use with desired CICD platform for easy cross platform PowerShell development.
-
-

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 2.22.2
+Help Version: 2.23.0
 Locale: en-US
 ---
 

--- a/docs/Catesta.md
+++ b/docs/Catesta.md
@@ -2,7 +2,7 @@
 Module Name: Catesta
 Module Guid: 6796b193-9013-468a-b022-837749af2d06
 Download Help Link: NA
-Help Version: 2.22.0
+Help Version: 2.22.2
 Locale: en-US
 ---
 

--- a/docs/New-ModuleProject.md
+++ b/docs/New-ModuleProject.md
@@ -243,7 +243,7 @@ New-ModuleProject -ModuleParameters $moduleParameters -DestinationPath $outPutPa
 ```
 
 Scaffolds a PowerShell module project for integration with GitLab CI/CD Pipelines with the project code stored on GitLab.
-A full set of repository supporting files are included. 
+A full set of repository supporting files are included.
 The project is set up for integration with Read the Docs.
 
 ## PARAMETERS
@@ -357,7 +357,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -Verbose, -WarningAction, -WarningVariable, and -ProgressAction. 
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -Verbose, -WarningAction, -WarningVariable, and -ProgressAction.
 For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/docs/New-ModuleProject.md
+++ b/docs/New-ModuleProject.md
@@ -8,16 +8,18 @@ schema: 2.0.0
 # New-ModuleProject
 
 ## SYNOPSIS
+
 Scaffolds a PowerShell module project for use with desired CICD platform for easy cross platform PowerShell development.
 
 ## SYNTAX
 
-```
+```powershell
 New-ModuleProject [-DestinationPath] <String> [-ModuleParameters <Hashtable>] [-NoLogo] [-PassThru] [-Force]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 Uses the Plaster framework to scaffold a PowerShell module that adheres to community best practices.
 Based on selections made, generates the files and configuration required to integrate with a variety of CI/CD platforms,
 including options for easy cross-platform verification on Windows, Linux, and MacOS.
@@ -31,7 +33,8 @@ If you pass in a full ModuleParameters set, Plaster will not prompt you for any 
 ## EXAMPLES
 
 ### EXAMPLE 1
-```
+
+```powershell
 New-ModuleProject -DestinationPath $outPutPath
 ```
 
@@ -39,7 +42,8 @@ Initiates Plaster template to scaffold a PowerShell module project with customiz
 Choices made during scaffolding will result in a PowerShell project tailored to the chosen CI/CD platform, or a standard PowerShell module project with no CI/CD integration.
 
 ### EXAMPLE 2
-```
+
+```powershell
 New-ModuleProject -DestinationPath $outPutPath -NoLogo
 ```
 
@@ -48,7 +52,8 @@ Choices made during scaffolding will result in a PowerShell project tailored to 
 The Plaster logo will be suppressed and not shown.
 
 ### EXAMPLE 3
-```
+
+```powershell
 New-ModuleProject -DestinationPath $outPutPath -PassThru
 ```
 
@@ -57,7 +62,8 @@ Choices made during scaffolding will result in a PowerShell project tailored to 
 An object will be returned containing details of the Plaster template deployment.
 
 ### EXAMPLE 4
-```
+
+```powershell
 $moduleParameters = @{
     ModuleName  = 'ModuleName'
     Description = 'My awesome module is awesome'
@@ -77,7 +83,8 @@ Scaffolds a basic PowerShell module project with no additional extras.
 You just get a basic PowerShell module construct.
 
 ### EXAMPLE 5
-```
+
+```powershell
 $moduleParameters = @{
     ModuleName     = 'ModuleName'
     Description    = 'My awesome module is awesome'
@@ -107,7 +114,8 @@ A full set of GitHub project supporting files is provided.
 The project is set up for integration with Read the Docs.
 
 ### EXAMPLE 6
-```
+
+```powershell
 $moduleParameters = @{
     ModuleName  = 'ModuleName'
     Description = 'My awesome module is awesome'
@@ -135,7 +143,8 @@ Scaffolds a PowerShell module project for integration with AWS CodeBuild with th
 A full set of GitHub project supporting files is provided.
 
 ### EXAMPLE 7
-```
+
+```powershell
 $moduleParameters = @{
     ModuleName   = 'ModuleName'
     Description  = 'My awesome module is awesome'
@@ -162,7 +171,8 @@ Scaffolds a PowerShell module project for integration with Azure Pipelines with 
 No repository supporting files are included.
 
 ### EXAMPLE 8
-```
+
+```powershell
 $moduleParameters = @{
     ModuleName      = 'ModuleName'
     Description     = 'My awesome module is awesome'
@@ -190,7 +200,8 @@ Scaffolds a PowerShell module project for integration with Appveyor with the pro
 No repository supporting files are included.
 
 ### EXAMPLE 9
-```
+
+```powershell
 $moduleParameters = @{
     ModuleName  = 'ModuleName'
     Description = 'My awesome module is awesome'
@@ -217,7 +228,8 @@ Scaffolds a PowerShell module project for integration with Bitbucket Pipelines w
 A full set of repository supporting files are included.
 
 ### EXAMPLE 10
-```
+
+```powershell
 $moduleParameters = @{
     ModuleName    = 'ModuleName'
     Description   = 'My awesome module is awesome'
@@ -243,12 +255,13 @@ New-ModuleProject -ModuleParameters $moduleParameters -DestinationPath $outPutPa
 ```
 
 Scaffolds a PowerShell module project for integration with GitLab CI/CD Pipelines with the project code stored on GitLab.
-A full set of repository supporting files are included.
+A full set of repository supporting files are included. 
 The project is set up for integration with Read the Docs.
 
 ## PARAMETERS
 
 ### -DestinationPath
+
 File path where PowerShell Module project will be created
 
 ```yaml
@@ -264,6 +277,7 @@ Accept wildcard characters: False
 ```
 
 ### -ModuleParameters
+
 Provide all Plaster decisions inside a Hashtable.
 If any decision choice is not provided, Plaster will still prompt you for a decision.
 See NOTES for additional limitations.
@@ -281,6 +295,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoLogo
+
 Suppresses the display of the Plaster logo.
 
 ```yaml
@@ -296,6 +311,7 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns an object containing details of Plaster template deployment.
 
 ```yaml
@@ -311,6 +327,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Skip Confirmation
 
 ```yaml
@@ -326,6 +343,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -342,6 +360,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -357,7 +376,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -Verbose, -WarningAction, -WarningVariable, and -ProgressAction.
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -Verbose, -WarningAction, -WarningVariable, and -ProgressAction. 
 For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -365,7 +385,9 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## OUTPUTS
 
 ### System.Management.Automation.PSCustomObject
+
 ## NOTES
+
 Author: Jake Morrison - @jakemorrison - https://www.techthoughts.info/
 
 Catesta Plaster templates have dynamic choices.

--- a/docs/New-VaultProject.md
+++ b/docs/New-VaultProject.md
@@ -8,16 +8,18 @@ schema: 2.0.0
 # New-VaultProject
 
 ## SYNOPSIS
+
 Scaffolds a PowerShell SecretManagement vault project for use with desired CICD platform for easy cross platform PowerShell development.
 
 ## SYNTAX
 
-```
+```powershell
 New-VaultProject [-DestinationPath] <String> [[-VaultParameters] <Hashtable>] [-NoLogo] [-PassThru] [-Force]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 Uses the Plaster framework to scaffold a PowerShell SecretManagement vault project that adheres to community best practices.
 Based on selections made, generates the files and configuration required to integrate with a variety of CI/CD platforms,
 including options for easy cross-platform verification on Windows, Linux, and MacOS.
@@ -30,7 +32,8 @@ If you pass in a full VaultParameters set, Plaster will not prompt you for any t
 ## EXAMPLES
 
 ### EXAMPLE 1
-```
+
+```powershell
 New-VaultProject -DestinationPath $outPutPath
 ```
 
@@ -38,7 +41,8 @@ Initiates Plaster template to scaffold a PowerShell SecretManagement vault proje
 Choices made during scaffolding will result in a PowerShell project tailored to the chosen CI/CD platform, or a standard PowerShell SecretManagement vault project with no CI/CD integration.
 
 ### EXAMPLE 2
-```
+
+```powershell
 New-VaultProject -DestinationPath $outPutPath -NoLogo
 ```
 
@@ -47,7 +51,8 @@ Choices made during scaffolding will result in a PowerShell project tailored to 
 The Plaster logo will be suppressed and not shown.
 
 ### EXAMPLE 3
-```
+
+```powershell
 New-VaultProject -DestinationPath $outPutPath -PassThru
 ```
 
@@ -56,7 +61,8 @@ Choices made during scaffolding will result in a PowerShell project tailored to 
 An object will be returned containing details of the Plaster template deployment.
 
 ### EXAMPLE 4
-```
+
+```powershell
 $vaultParameters = @{
     ModuleName       = 'SecretManagement.VaultName'
     Description      = 'My awesome vault is awesome'
@@ -75,7 +81,8 @@ Scaffolds a basic PowerShell SecretManagement vault project with no additional e
 You just get a basic PowerShell SecretManagement vault construct.
 
 ### EXAMPLE 5
-```
+
+```powershell
 $vaultParameters = @{
     ModuleName     = 'SecretManagement.VaultName'
     Description    = 'My awesome vault is awesome'
@@ -104,7 +111,8 @@ A full set of GitHub project supporting files is provided.
 The project is set up for integration with Read the Docs.
 
 ### EXAMPLE 6
-```
+
+```powershell
 $vaultParameters = @{
     ModuleName  = 'SecretManagement.VaultName'
     Description = 'My awesome vault is awesome'
@@ -131,7 +139,8 @@ Scaffolds a PowerShell SecretManagement vault project for integration with AWS C
 A full set of GitHub project supporting files is provided.
 
 ### EXAMPLE 7
-```
+
+```powershell
 $vaultParameters = @{
     ModuleName   = 'SecretManagement.VaultName'
     Description  = 'My awesome vault is awesome'
@@ -157,7 +166,8 @@ Scaffolds a PowerShell SecretManagement vault project for integration with Azure
 No repository supporting files are included.
 
 ### EXAMPLE 8
-```
+
+```powershell
 $vaultParameters = @{
     ModuleName      = 'SecretManagement.VaultName'
     Description     = 'My awesome vault is awesome'
@@ -184,7 +194,8 @@ Scaffolds a PowerShell SecretManagement vault project for integration with Appve
 No repository supporting files are included.
 
 ### EXAMPLE 9
-```
+
+```powershell
 $vaultParameters = @{
     ModuleName  = 'SecretManagement.VaultName'
     Description = 'My awesome vault is awesome'
@@ -210,7 +221,8 @@ Scaffolds a PowerShell SecretManagement vault project for integration with Bitbu
 A full set of repository supporting files are included.
 
 ### EXAMPLE 10
-```
+
+```powershell
 $vaultParameters = @{
     ModuleName    = 'SecretManagement.VaultName'
     Description   = 'My awesome vault is awesome'
@@ -241,6 +253,7 @@ The project is set up for integration with Read the Docs.
 ## PARAMETERS
 
 ### -DestinationPath
+
 File path where PowerShell SecretManagement vault project will be created
 
 ```yaml
@@ -256,6 +269,7 @@ Accept wildcard characters: False
 ```
 
 ### -VaultParameters
+
 Provide all Plaster decisions inside a Hashtable.
 If any decision choice is not provided, Plaster will still prompt you for a decision.
 See NOTES for additional limitations.
@@ -273,6 +287,7 @@ Accept wildcard characters: False
 ```
 
 ### -NoLogo
+
 Suppresses the display of the Plaster logo.
 
 ```yaml
@@ -288,6 +303,7 @@ Accept wildcard characters: False
 ```
 
 ### -PassThru
+
 Returns an object containing details of Plaster template deployment.
 
 ```yaml
@@ -303,6 +319,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Skip Confirmation
 
 ```yaml
@@ -318,6 +335,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -334,6 +352,7 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -349,6 +368,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -Verbose, -WarningAction, -WarningVariable, and -ProgressAction. 
 For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
@@ -357,7 +377,9 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## OUTPUTS
 
 ### System.Management.Automation.PSCustomObject
+
 ## NOTES
+
 Author: Jake Morrison - @jakemorrison - https://www.techthoughts.info/
 
 ## RELATED LINKS

--- a/src/Catesta.build.ps1
+++ b/src/Catesta.build.ps1
@@ -168,7 +168,11 @@ Add-BuildTask Analyze {
         Setting = 'PSScriptAnalyzerSettings.psd1'
     }
 
-    $filesToAnalyze = Get-ChildItem -Path $script:ModuleSourcePath -Exclude "PSVault.Extension*" -Recurse -File | Where-Object { $_.FullName -notlike '*\Tests\*' }
+    $filesToAnalyze = Get-ChildItem -Path $script:ModuleSourcePath -Exclude "PSVault.Extension*" -Recurse -File |
+    Where-Object {
+        $directoryPath = [System.IO.Path]::GetDirectoryName($_.FullName)
+        $directoryPath -notmatch 'Tests'
+    }
     $fileCount = $filesToAnalyze.Count
 
     Write-Build White ('      Performing Module ScriptAnalyzer checks for {0} files...' -f $fileCount)

--- a/src/Catesta.build.ps1
+++ b/src/Catesta.build.ps1
@@ -144,6 +144,7 @@ Add-BuildTask ImportModuleManifest {
         Import-Module $script:ModuleManifestFile -Force -PassThru -ErrorAction Stop
     }
     catch {
+        Write-Build Red "      ...$_`n"
         throw 'Unable to load the project module'
     }
     Write-Build Green "      ...$script:ModuleName imported successfully"

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.23.0'
+    ModuleVersion     = '2.24.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.22.2'
+    ModuleVersion     = '2.23.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.24.0'
+    ModuleVersion     = '2.27.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Catesta.psd1
+++ b/src/Catesta/Catesta.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Catesta.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.22.0'
+    ModuleVersion     = '2.22.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/Catesta/Resources/AWS/install_modules.ps1
+++ b/src/Catesta/Resources/AWS/install_modules.ps1
@@ -59,7 +59,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 [void]$modulesToInstall.Add(([PSCustomObject]@{
     ModuleName    = 'Pester'
-    ModuleVersion = '5.6.1'
+    ModuleVersion = '5.7.1'
     BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
     KeyPrefix     = ''
 }))
@@ -68,13 +68,13 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 %>
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.11.3'
+            ModuleVersion = '5.12.1'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.22.0'
+            ModuleVersion = '1.23.0'
             BucketName    = '<%=$PLASTER_PARAM_S3Bucket%>'
             KeyPrefix     = ''
         }))

--- a/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/AppVeyor/actions_bootstrap.ps1
@@ -23,7 +23,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.6.1'
+            ModuleVersion = '5.7.1'
         }))
 '@
 }
@@ -31,12 +31,12 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/nightroman/Invoke-Build
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.11.3'
+            ModuleVersion = '5.12.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.22.0'
+            ModuleVersion = '1.23.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/src/Catesta/Resources/Azure/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/Azure/actions_bootstrap.ps1
@@ -23,7 +23,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.6.1'
+            ModuleVersion = '5.7.1'
         }))
 '@
 }
@@ -31,12 +31,12 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/nightroman/Invoke-Build
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.11.3'
+            ModuleVersion = '5.12.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.22.0'
+            ModuleVersion = '1.23.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/src/Catesta/Resources/Bitbucket/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/Bitbucket/actions_bootstrap.ps1
@@ -23,7 +23,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.6.1'
+            ModuleVersion = '5.7.1'
         }))
 '@
 }
@@ -31,12 +31,12 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/nightroman/Invoke-Build
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.11.3'
+            ModuleVersion = '5.12.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.22.0'
+            ModuleVersion = '1.23.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/GitHubActions/actions_bootstrap.ps1
@@ -23,7 +23,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.6.1'
+            ModuleVersion = '5.7.1'
         }))
 '@
 }
@@ -31,12 +31,12 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/nightroman/Invoke-Build
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.11.3'
+            ModuleVersion = '5.12.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.22.0'
+            ModuleVersion = '1.23.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/src/Catesta/Resources/GitHubActions/workflows/wf_Linux.yml
+++ b/src/Catesta/Resources/GitHubActions/workflows/wf_Linux.yml
@@ -41,13 +41,13 @@ jobs:
       shell: pwsh
       run: Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
     - name: Upload pester results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pester-results
         path: ./src/Artifacts/testOutput
         if-no-files-found: warn
     - name: Upload zip module archive build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: zip-archive
         path: ./src/Archive

--- a/src/Catesta/Resources/GitHubActions/workflows/wf_MacOS.yml
+++ b/src/Catesta/Resources/GitHubActions/workflows/wf_MacOS.yml
@@ -41,13 +41,13 @@ jobs:
       shell: pwsh
       run: Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
     - name: Upload pester results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pester-results
         path: ./src/Artifacts/testOutput
         if-no-files-found: warn
     - name: Upload zip module archive build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: zip-archive
         path: ./src/Archive

--- a/src/Catesta/Resources/GitHubActions/workflows/wf_Windows.yml
+++ b/src/Catesta/Resources/GitHubActions/workflows/wf_Windows.yml
@@ -47,13 +47,13 @@ jobs:
       shell: powershell
       run: Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
     - name: Upload pester results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pester-results
         path: .\src\Artifacts\testOutput
         if-no-files-found: warn
     - name: Upload zip module archive build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: zip-archive
         path: .\src\Archive

--- a/src/Catesta/Resources/GitHubActions/workflows/wf_Windows_Core.yml
+++ b/src/Catesta/Resources/GitHubActions/workflows/wf_Windows_Core.yml
@@ -41,13 +41,13 @@ jobs:
       shell: pwsh
       run: Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
     - name: Upload pester results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pester-results
         path: .\src\Artifacts\testOutput
         if-no-files-found: warn
     - name: Upload zip module archive build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: zip-archive
         path: .\src\Archive

--- a/src/Catesta/Resources/GitHubActionsCodeBuild/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/GitHubActionsCodeBuild/actions_bootstrap.ps1
@@ -23,7 +23,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.6.1'
+            ModuleVersion = '5.7.1'
         }))
 '@
 }
@@ -31,12 +31,12 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/nightroman/Invoke-Build
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.11.3'
+            ModuleVersion = '5.12.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.22.0'
+            ModuleVersion = '1.23.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/src/Catesta/Resources/GitHubActionsCodeBuild/workflows/wf_Linux.yml
+++ b/src/Catesta/Resources/GitHubActionsCodeBuild/workflows/wf_Linux.yml
@@ -45,13 +45,13 @@ jobs:
       shell: pwsh
       run: Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
     - name: Upload pester results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pester-results
         path: ./src/Artifacts/testOutput
         if-no-files-found: warn
     - name: Upload zip module archive build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: zip-archive
         path: ./src/Archive

--- a/src/Catesta/Resources/GitHubActionsCodeBuild/workflows/wf_Windows.yml
+++ b/src/Catesta/Resources/GitHubActionsCodeBuild/workflows/wf_Windows.yml
@@ -49,13 +49,13 @@ jobs:
       shell: powershell
       run: Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
     - name: Upload pester results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pester-results
         path: .\src\Artifacts\testOutput
         if-no-files-found: warn
     - name: Upload zip module archive build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: zip-archive
         path: .\src\Archive

--- a/src/Catesta/Resources/GitHubActionsCodeBuild/workflows/wf_Windows_Core.yml
+++ b/src/Catesta/Resources/GitHubActionsCodeBuild/workflows/wf_Windows_Core.yml
@@ -43,13 +43,13 @@ jobs:
       shell: pwsh
       run: Invoke-Build -File .\src\<%=$PLASTER_PARAM_ModuleName%>.build.ps1
     - name: Upload pester results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pester-results
         path: .\src\Artifacts\testOutput
         if-no-files-found: warn
     - name: Upload zip module archive build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: zip-archive
         path: .\src\Archive

--- a/src/Catesta/Resources/GitLab/actions_bootstrap.ps1
+++ b/src/Catesta/Resources/GitLab/actions_bootstrap.ps1
@@ -23,7 +23,7 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/pester/Pester
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.6.1'
+            ModuleVersion = '5.7.1'
         }))
 '@
 }
@@ -31,12 +31,12 @@ elseif ($PLASTER_PARAM_Pester-eq '5') {
 # https://github.com/nightroman/Invoke-Build
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.11.3'
+            ModuleVersion = '5.12.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 [void]$modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.22.0'
+            ModuleVersion = '1.23.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/src/Catesta/Resources/Module/plasterManifest.xml
+++ b/src/Catesta/Resources/Module/plasterManifest.xml
@@ -19,7 +19,7 @@
     <metadata>
         <name>Catesta</name>
         <id>258a61ba-566b-4c3a-8230-c2b6861a1a8d</id>
-        <version>2.23.0</version>
+        <version>2.24.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Module/plasterManifest.xml
+++ b/src/Catesta/Resources/Module/plasterManifest.xml
@@ -19,7 +19,7 @@
     <metadata>
         <name>Catesta</name>
         <id>258a61ba-566b-4c3a-8230-c2b6861a1a8d</id>
-        <version>2.22.2</version>
+        <version>2.23.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Module/plasterManifest.xml
+++ b/src/Catesta/Resources/Module/plasterManifest.xml
@@ -19,7 +19,7 @@
     <metadata>
         <name>Catesta</name>
         <id>258a61ba-566b-4c3a-8230-c2b6861a1a8d</id>
-        <version>2.24.0</version>
+        <version>2.27.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Module/plasterManifest.xml
+++ b/src/Catesta/Resources/Module/plasterManifest.xml
@@ -19,7 +19,7 @@
     <metadata>
         <name>Catesta</name>
         <id>258a61ba-566b-4c3a-8230-c2b6861a1a8d</id>
-        <version>2.22.0</version>
+        <version>2.22.2</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Module/src/MarkdownRepair.ps1
+++ b/src/Catesta/Resources/Module/src/MarkdownRepair.ps1
@@ -11,6 +11,7 @@
 #>
 
 function Remove-CommonParameterFromMarkdown {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
     <#
     .SYNOPSIS
         Remove a PlatyPS generated parameter block.

--- a/src/Catesta/Resources/Module/src/PSModule.build.ps1
+++ b/src/Catesta/Resources/Module/src/PSModule.build.ps1
@@ -177,6 +177,7 @@ Add-BuildTask ImportModuleManifest {
         Import-Module $script:ModuleManifestFile -Force -PassThru -ErrorAction Stop
     }
     catch {
+        Write-Build Red "      ...$_`n"
         throw 'Unable to load the project module'
     }
     Write-Build Green "      ...$script:ModuleName imported successfully"

--- a/src/Catesta/Resources/Module/src/PSModule.build.ps1
+++ b/src/Catesta/Resources/Module/src/PSModule.build.ps1
@@ -313,7 +313,7 @@ Add-BuildTask FormattingCheck {
 Add-BuildTask Test {
 
     Write-Build White "      Importing desired Pester version. Min: $script:MinPesterVersion Max: $script:MaxPesterVersion"
-    Remove-Module -Name Pester -Force -ErrorAction SilentlyContinue # there are instances where some containers have Pester already in the session
+    Remove-Module -Name Pester -Force -ErrorAction 'SilentlyContinue'# there are instances where some containers have Pester already in the session
     Import-Module -Name Pester -MinimumVersion $script:MinPesterVersion -MaximumVersion $script:MaxPesterVersion -ErrorAction 'Stop'
 
     $codeCovPath = "$script:ArtifactsPath\ccReport\"
@@ -505,7 +505,7 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
     Write-Build Gray '           ...Markdown generation completed.'
 
     Write-Build Gray '           Replacing markdown elements...'
-    # Replace multi-line EXAMPLES
+    Write-Build DarkGray '             Replace multi-line EXAMPLES'
     $OutputDir = "$script:ArtifactsPath\docs\"
     $OutputDir | Get-ChildItem -File | ForEach-Object {
         # fix formatting in multiline examples
@@ -515,7 +515,7 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
             Set-Content -Path $_.FullName -Value $newContent -Force
         }
     }
-    # Replace each missing element we need for a proper generic module page .md file
+    Write-Build DarkGray '             Replace each missing element we need for a proper generic module page .md file'
     $ModulePageFileContent = Get-Content -Raw $ModulePage
     $ModulePageFileContent = $ModulePageFileContent -replace '{{Manually Enter Description Here}}', $script:ModuleDescription
     $script:FunctionsToExport | ForEach-Object {
@@ -524,6 +524,27 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
         $ReplacementText = (Get-Help -Detailed $_).Synopsis
         $ModulePageFileContent = $ModulePageFileContent -replace $TextToReplace, $ReplacementText
     }
+    Write-Build DarkGray '             Evaluating if running 7.4.0 or higher...'
+    # https://github.com/PowerShell/platyPS/issues/595
+    if ($PSVersionTable.PSVersion -ge [version]'7.4.0') {
+        Write-Build DarkGray '                Performing Markdown repair'
+        # dot source markdown repair
+        . $BuildRoot\MarkdownRepair.ps1
+        $OutputDir | Get-ChildItem -File | ForEach-Object {
+            Repair-PlatyPSMarkdown -Path $_.FullName
+        }
+    }
+    Write-Build DarkGray '             Add blank line after headers.'
+    $OutputDir | Get-ChildItem -File | ForEach-Object {
+        $content = Get-Content $_.FullName -Raw
+        $newContent = $content -replace '(?m)^(#{1,6}\s+.*)$\r?\n(?!\r?\n)', "`$1`r`n"
+        # $newContent = $content -replace '(?m)^(#{1,6}\s+.+?)$\r?\n(?!\r?\n)', "`$1`n"
+        # $newContent = $content -replace '(?m)^(#{1,6}\s+.*)$\r?\n(?!\r?\n)', "`$1`n"
+        if ($newContent -ne $content) {
+            Set-Content -Path $_.FullName -Value $newContent -Force
+        }
+    }
+    # *NOTE: it is not possible to adjust fenced code block at this location as conversion to MAML does not support language tags.
 
     $ModulePageFileContent | Out-File $ModulePage -Force -Encoding:utf8
     Write-Build Gray '           ...Markdown replacements complete.'
@@ -533,17 +554,6 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
     if ($MissingGUID.Count -gt 0) {
         Write-Build Yellow '             The documentation that got generated resulted in a generic GUID. Check the GUID entry of your module manifest.'
         throw 'Missing GUID. Please review and rebuild.'
-    }
-
-    Write-Build Gray '           Evaluating if running 7.4.0 or higher...'
-    # https://github.com/PowerShell/platyPS/issues/595
-    if ($PSVersionTable.PSVersion -ge [version]'7.4.0') {
-        Write-Build Gray '               Performing Markdown repair'
-        # dot source markdown repair
-        . $BuildRoot\MarkdownRepair.ps1
-        $OutputDir | Get-ChildItem -File | ForEach-Object {
-            Repair-PlatyPSMarkdown -Path $_.FullName
-        }
     }
 
     Write-Build Gray '           Checking for missing documentation in md files...'
@@ -559,7 +569,8 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
 
     Write-Build Gray '           Checking for missing SYNOPSIS in md files...'
     $fSynopsisOutput = @()
-    $synopsisEval = Select-String -Path "$script:ArtifactsPath\docs\*.md" -Pattern "^## SYNOPSIS$" -Context 0, 1
+    # $synopsisEval = Select-String -Path "$script:ArtifactsPath\docs\*.md" -Pattern "^## SYNOPSIS$" -Context 0, 1
+    $synopsisEval = Select-String -Path "$script:ArtifactsPath\docs\*.md" -Pattern "^## SYNOPSIS$\r?\n$" -Context 0, 2
     $synopsisEval | ForEach-Object {
         $chAC = $_.Context.DisplayPostContext.ToCharArray()
         if ($null -eq $chAC) {
@@ -583,6 +594,57 @@ Add-BuildTask CreateExternalHelp -After CreateMarkdownHelp {
 } #CreateExternalHelp
 
 Add-BuildTask CreateHelpComplete -After CreateExternalHelp {
+    Write-Build Gray '           Finalizing markdown documentation now that external help has been created...'
+    Write-Build DarkGray '             Add powershell language to unspecified fenced code blocks.'
+
+    $OutputDir = "$script:ArtifactsPath\docs\"
+
+    Get-ChildItem -Path $OutputDir -File | ForEach-Object {
+        $lines = Get-Content -Path $_.FullName
+        $insideCodeBlock = $false
+
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            # Regex captures everything after triple backticks (if present).
+            # e.g. ```yaml => captured group = "yaml"
+            #      ```    => captured group = ""
+            if ($lines[$i] -match '^\s*```(\S*)\s*$') {
+                $lang = $Matches[1]
+
+                if (-not $insideCodeBlock) {
+                    # We found an opening fence
+                    if ([string]::IsNullOrWhiteSpace($lang)) {
+                        # Bare triple backticks => add powershell
+                        $lines[$i] = '```powershell'
+                    }
+                    # Toggle "inside code block" on
+                    $insideCodeBlock = $true
+                }
+                else {
+                    # We found the closing fence -> set $insideCodeBlock off
+                    $insideCodeBlock = $false
+                    # Do *not* modify closing fence, leave it exactly as it is
+                }
+            }
+        }
+
+        Set-Content -Path $_.FullName -Value $lines
+    }
+    Write-Build DarkGray '             Ensuring exactly one trailing newline in final markdown file.'
+    Get-ChildItem -Path $OutputDir -File -Filter *.md | ForEach-Object {
+        # Read the file as an array of lines
+        $lines = Get-Content -Path $_.FullName
+
+        # Remove all blank lines at the end, but do not remove actual content
+        while ($lines.Count -gt 0 -and $lines[-1] -match '^\s*$') {
+            $lines = $lines[0..($lines.Count - 2)]
+        }
+
+        # Re-join with Windows line endings and add exactly one trailing newline
+        $content = ($lines -join "`r`n")
+        Set-Content -Path $_.FullName -Value $content -Force
+    }
+    Write-Build Gray '           ...Markdown documentation finalized.'
+
     Write-Build Green '      ...CreateHelp Complete!'
 } #CreateHelpStart
 

--- a/src/Catesta/Resources/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Vault/plasterManifest.xml
@@ -6,7 +6,7 @@
     <metadata>
         <name>Catesta</name>
         <id>d531e058-52b8-4dd2-8162-01c95d1eb8f7</id>
-        <version>2.24.0</version>
+        <version>2.27.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell SecretManagement extension vault module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Vault/plasterManifest.xml
@@ -6,7 +6,7 @@
     <metadata>
         <name>Catesta</name>
         <id>d531e058-52b8-4dd2-8162-01c95d1eb8f7</id>
-        <version>2.22.0</version>
+        <version>2.22.2</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell SecretManagement extension vault module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Vault/plasterManifest.xml
@@ -6,7 +6,7 @@
     <metadata>
         <name>Catesta</name>
         <id>d531e058-52b8-4dd2-8162-01c95d1eb8f7</id>
-        <version>2.22.2</version>
+        <version>2.23.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell SecretManagement extension vault module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Vault/plasterManifest.xml
+++ b/src/Catesta/Resources/Vault/plasterManifest.xml
@@ -6,7 +6,7 @@
     <metadata>
         <name>Catesta</name>
         <id>d531e058-52b8-4dd2-8162-01c95d1eb8f7</id>
-        <version>2.23.0</version>
+        <version>2.24.0</version>
         <title>Catesta</title>
         <description>Scaffolds a new PowerShell SecretManagement extension vault module project</description>
         <author>Jake Morrison</author>

--- a/src/Catesta/Resources/Vault/src/PSVault.build.ps1
+++ b/src/Catesta/Resources/Vault/src/PSVault.build.ps1
@@ -166,6 +166,7 @@ Add-BuildTask ImportModuleManifest {
         Import-Module $script:ModuleManifestFile -Force -PassThru -ErrorAction Stop
     }
     catch {
+        Write-Build Red "      ...$_`n"
         throw 'Unable to load the project module'
     }
     Write-Build Green "      ...$script:ModuleName imported successfully"

--- a/src/MarkdownRepair.ps1
+++ b/src/MarkdownRepair.ps1
@@ -11,6 +11,7 @@
 #>
 
 function Remove-CommonParameterFromMarkdown {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
     <#
     .SYNOPSIS
         Remove a PlatyPS generated parameter block.


### PR DESCRIPTION
# Pull Request

## Issue

- #99
- #100 
- #101 
- #103

## Description

- Catesta template module changes
    - Updated all GitHub actions workflows from `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
    - `*.build.ps1` Improvements:
        - `Invoke-Formatter` now runs at the end of `Build` step for final cleanup
        - Added new Markdown processing functionality to address two Markdown linting issues:
            - `MD022/blanks-around-headings`
            - `MD040/fenced-code-language`
        - Added more detailed error output to `ImportModuleManifest`
    - CI/CD Changes:
        - Pester bumped from `5.6.1` to `5.7.1`
        - InvokeBuild bumped from `5.11.3` to `5.12.1`
        - PSScriptAnalyzer bumped from `1.22.0` to `1.23.0`
- Catesta primary module changes
    - Updated GitHub actions workflows from `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
    - `Catesta.build.ps1` Improvements:
        - `Invoke-Formatter` now runs at the end of `Build` step for final cleanup
        - Added new Markdown processing functionality to address two Markdown linting issues:
            - `MD022/blanks-around-headings`
            - `MD040/fenced-code-language`
        - Added more detailed error output to `ImportModuleManifest`
    - Pester bumped from `5.6.1` to `5.7.1`
    - InvokeBuild bumped from `5.11.3` to `5.12.1`
    - PSScriptAnalyzer bumped from `1.22.0` to `1.23.0`

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
